### PR TITLE
Issue #19 : Truncating variables decimals

### DIFF
--- a/totalRP3_Extended/quest/quest_log.lua
+++ b/totalRP3_Extended/quest/quest_log.lua
@@ -83,7 +83,7 @@ local function getCampaignProgression(campaignID)
 		end
 	end
 	if total ~= 0 then
-		return (completed / total) * 100;
+		return TRP3_API.extended.tools.truncateDecimals( (completed / total) * 100, 0);
 	else
 		return 0;
 	end

--- a/totalRP3_Extended/quest/quest_log.lua
+++ b/totalRP3_Extended/quest/quest_log.lua
@@ -83,7 +83,7 @@ local function getCampaignProgression(campaignID)
 		end
 	end
 	if total ~= 0 then
-		return TRP3_API.extended.tools.truncateDecimals( (completed / total) * 100, 0);
+		return math.floor( (completed / total) * 100);
 	else
 		return 0;
 	end

--- a/totalRP3_Extended/script/script_generation.lua
+++ b/totalRP3_Extended/script/script_generation.lua
@@ -796,6 +796,11 @@ function TRP3_API.script.parseArgs(text, args)
 			default = capture:sub(capture:find("::") + 2);
 			capture = capture:sub(1, capture:find("::") - 1);
 		end
+		local decimals = 2;
+		if capture:find("#") then
+			decimals = tonumber(capture:sub(capture:find("#") + 1) or 2) or 2;
+			capture = capture:sub(1, capture:find("#") - 1);
+		end
 		if directReplacement[capture] then
 			return directReplacement[capture](args);
 		elseif capture:match("gender%:%w+%:[^%:]+%:[^%:]+") then
@@ -808,11 +813,11 @@ function TRP3_API.script.parseArgs(text, args)
 			return UNKNOWN;
 		elseif capture:match("event%.%d+") then
 			local index = tonumber(capture:match("event%.(%d+)") or 1) or 1;
-			return (args.event or EMPTY)[index] or capture;
+			return TRP3_API.extended.tools.truncateDecimals( (args.event or EMPTY)[index] or capture, decimals);
 		elseif (args.custom or EMPTY)[capture] or ((args.object or EMPTY).vars or EMPTY)[capture] then
-			return (args.custom or EMPTY)[capture] or ((args.object or EMPTY).vars or EMPTY)[capture];
+			return TRP3_API.extended.tools.truncateDecimals( (args.custom or EMPTY)[capture] or ((args.object or EMPTY).vars or EMPTY)[capture], decimals);
 		elseif ((TRP3_API.quest.getActiveCampaignLog() or EMPTY).vars or EMPTY)[capture] then
-			return ((TRP3_API.quest.getActiveCampaignLog() or EMPTY).vars or EMPTY)[capture];
+			return TRP3_API.extended.tools.truncateDecimals( ((TRP3_API.quest.getActiveCampaignLog() or EMPTY).vars or EMPTY)[capture], decimals);
 		elseif TRP3_API.extended.classExists(capture) then
 			return TRP3_API.inventory.getItemLink(TRP3_API.extended.getClass(capture), capture);
 		end

--- a/totalRP3_Extended_Tools/main.lua
+++ b/totalRP3_Extended_Tools/main.lua
@@ -396,6 +396,18 @@ function TRP3_API.extended.tools.getSaveTab(fullClassID, maxTabSize)
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
+-- Misc functions
+--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
+
+function TRP3_API.extended.tools.truncateDecimals(args, decimals)
+	if decimals and tonumber(args) then
+		local tenpow = 10 ^ decimals;
+		args = tostring( floor( tonumber(args) * tenpow + 0.5 ) / tenpow ) or "0";
+	end
+	return args;
+end
+
+--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- INIT
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 


### PR DESCRIPTION
Variables are now automatically truncated to 2 decimals when parsed. You can use ${variable#X} to truncate a variable to X decimals.

I'm also flooring the campaign progress percentage, as it doesn't really need decimal precision.