### PR TITLE
Issue #45 : "Next step index" cutscene bottom text

### DIFF
--- a/totalRP3_Extended/dialogues/dialogues.lua
+++ b/totalRP3_Extended/dialogues/dialogues.lua
@@ -225,7 +225,7 @@ local function playDialogStep()
 	dialogFrame.Chat.Text:SetText(text);
 	dialogFrame.Chat.start = 0; -- Automatically starts the fade-in animation for text
 
-	dialogFrame.Chat.Next:SetText(loc.DI_NEXT);
+	dialogFrame.Chat.Next:SetText("");
 	dialogFrame.Chat.NextButton:Enable();
 	if not dialogFrame.isPreview and dialogFrame.LO then
 		dialogFrame.Chat.NextButton:Disable();
@@ -243,6 +243,7 @@ local function playDialogStep()
 		-- If there is a choice to make
 		if dialogStepClass.CH then
 			setupChoices(dialogStepClass.CH);
+			dialogFrame.Chat.Next:SetText(loc.DI_CHOICE_TEXT);
 			dialogFrame.Chat.NextButton:Disable();
 		else
 			if dialogStepClass.EP then

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1213,6 +1213,7 @@ The function is in the form of:
 	DI_CHOICE_TT = "Enter the text for this option.\n\n|cff00ff00Leave empty to disable this option.",
 	DI_CHOICE_STEP = "Go to step",
 	DI_CHOICE_STEP_TT = "Enter the cutscene step number to play if the player selects this option.\n\n|cff00ff00If empty or invalid step index, it will end the cutscene if selected (and trigger the On finish object event).",
+	DI_CHOICE_TEXT = "Choose an option",
 	DI_HISTORY = "Cutscenes history",
 	DI_HISTORY_TT = "Click to see/hide the history panel, showing the previous cutscene lines.",
 	DI_NEXT = "Next step index",


### PR DESCRIPTION
I've removed the "Next step index" text at the bottom of cutscene dialogs. It was confusing, annoying, and served no purpose.
To compensate since I was there, I replaced it with a text to "Choose an option" when there are player choices, to make it coherent with the "Wait for loot" text.