### PR TITLE
Issue #18 : Added an alert popup when given inner ID has a space

### DIFF
--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1549,6 +1549,7 @@ You can easily see each quest current situation and what are the current objecti
 
 You can also see the history of previous steps, in case you forget something.]],
 
+	IN_INNER_ENTER_ID_NO_SPACE = "Object IDs can't contain spaces. Remember that this isn't the object's name !",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended_Tools/inner/inner.lua
+++ b/totalRP3_Extended_Tools/inner/inner.lua
@@ -224,6 +224,8 @@ local function addInnerObject(type, self)
 	TRP3_API.popup.showTextInputPopup(loc.IN_INNER_ENTER_ID .. "\n\n" .. loc.IN_INNER_ENTER_ID_TT, function(innerID)
 		if not innerID or innerID:len() == 0 then
 			return;
+		elseif innerID:find(" ") then
+			TRP3_API.popup.showAlertPopup(loc.IN_INNER_ENTER_ID_NO_SPACE);
 		elseif self == editor.browser.add then
 			createInnerObject(innerID, type);
 			refresh();


### PR DESCRIPTION
If the player inputs an ID containing at least one space character, it shows an alert popup reminding not to use them instead of creating the object and breaking everything.

*Locale at the bottom \o/*