### PR TITLE
Issue #9 : Delay before workflow callback from prompt

### DIFF
--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -395,14 +395,14 @@ local EFFECTS = {
 			TRP3_API.popup.showTextInputPopup(cArgs[1] or "",
 			function(value)
 				TRP3_API.script.setVar(eArgs, cArgs[3] or "o", "=", cArgs[2] or "var", value);
-				if cArgs[4] then
+				if cArgs[4] and cArgs[4] ~= "" then
 					TRP3_API.script.setVar(eArgs, "w", "=", cArgs[2] or "var", value);
-					TRP3_API.script.runWorkflow(eArgs, cArgs[5] or "o", cArgs[4]);
+					C_Timer.After(0.1, function() TRP3_API.script.runWorkflow(eArgs, cArgs[5] or "o", cArgs[4]) end);
 				end
 			end,
 			function(value)
-				if cArgs[4] then
-					TRP3_API.script.runWorkflow(eArgs, cArgs[5] or "o", cArgs[4]);
+				if cArgs[4] and cArgs[4] ~= "" then
+					C_Timer.After(0.1, function() TRP3_API.script.runWorkflow(eArgs, cArgs[5] or "o", cArgs[4]) end);
 				end
 			end, "");
 			eArgs.LAST = 0;


### PR DESCRIPTION
To prevent successive prompts issues, added a delay of 100 ms before calling the optional workflow.
I also fixed the workflow condition, which was inappropriately displaying an error message `Can't find workflow ""` when no workflow was optionally added.