### PR TITLE
Wrong icons when scanning stashes + reset bug

### DIFF
--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -146,7 +146,7 @@ local function initScans()
 			end
 			local line = Utils.str.icon(stash.BA.IC) .. " " .. getItemLink(stash);
 			marker.scanLine = line .. " - |cffff9900" .. total .. "/8";
-			marker.Icon:SetTexCoord(0.250, 0.375, 0.625, 0.750);
+			marker.iconAtlas = "VignetteLoot";
 		end,
 		noAnim = true,
 	});
@@ -190,7 +190,7 @@ local function initScans()
 		scanMarkerDecorator = function(index, entry, marker)
 			local line = Utils.str.icon(entry.BA.IC) .. " " .. getItemLink(entry);
 			marker.scanLine = line .. " - |cffff9900" .. entry.total .. "/8 |cff00ff00- " .. entry.sender;
-			marker.Icon:SetTexCoord(0.250, 0.375, 0.625, 0.750);
+			marker.iconAtlas = "VignetteLoot";
 		end,
 		scanDuration = 2.5;
 	});


### PR DESCRIPTION
Thanks to Meorawr's answer on the TRP ticket, managed to fix both stashes scan icon issues ( TRP3 \#120 & Extended #93 ).

The stashes now have the proper icon again, and it gets reset correctly when doing a character scan afterwards.

![image](https://user-images.githubusercontent.com/17127080/39667214-0e62649e-50b1-11e8-98d8-f01d8887e72d.png)
