### PR TITLE
Container frames fix

### DIFF
--- a/totalRP3_Extended/inventory/container.lua
+++ b/totalRP3_Extended/inventory/container.lua
@@ -823,6 +823,7 @@ local function getContainerInstance(container, class)
 		containerFrame.IconButton:SetScript("OnLeave", slotOnLeave);
 		initContainerInstance(containerFrame, size)
 		tinsert(containerInstances, containerFrame);
+		tinsert(UISpecialFrames, containerFrame:GetName());
 	end
 	containerFrame.info = container;
 	return containerFrame;

--- a/totalRP3_Extended/inventory/inventory.xml
+++ b/totalRP3_Extended/inventory/inventory.xml
@@ -238,7 +238,6 @@
 		<Scripts>
 			<OnLoad>
 				self.IconButton:SetAllPoints(self.Icon);
-				tinsert(UISpecialFrames, self:GetName());
 			</OnLoad>
 		</Scripts>
 
@@ -279,7 +278,6 @@
 			<OnLoad>
 				self.Middle:SetTexCoord(0.24, 1, 0.43, 0.4875);
 				self.IconButton:SetAllPoints(self.Icon);
-				tinsert(UISpecialFrames, self:GetName());
 			</OnLoad>
 		</Scripts>
 	</Frame>
@@ -293,7 +291,6 @@
 			<OnLoad>
 				self.Middle:SetTexCoord(0.24, 1, 0.43, 0.4);
 				self.IconButton:SetAllPoints(self.Icon);
-				tinsert(UISpecialFrames, self:GetName());
 			</OnLoad>
 		</Scripts>
 	</Frame>


### PR DESCRIPTION
Moved the addition to SpecialFrames from the XML to the bag instance creation, so only the bags are affected by it and not the loot/container editors.