### PR TITLE
Issue #46 : Added variable access in the script effect

### DIFF
--- a/totalRP3_Extended/script/script_generation.lua
+++ b/totalRP3_Extended/script/script_generation.lua
@@ -871,6 +871,10 @@ function TRP3_API.script.setVar(args, source, operationType, varName, varValue)
 	end
 end
 
+local function setVarValue(args, source, varName, varValue)
+	TRP3_API.script.setVar(args, source, "=", varName, varValue);
+end
+
 function TRP3_API.script.varCheck(args, source, varName)
 	if args and source then
 
@@ -966,7 +970,7 @@ function TRP3_API.script.runLuaScriptEffect(code, args, secured)
 	env["op"] = operand;
 
 	env["getVar"] = TRP3_API.script.varCheck;
-	env["setVar"] = TRP3_API.script.setVar;
+	env["setVar"] = setVarValue;
 
 	-- Compile
 	local factory, errorMessage = loadstring(code, "Generated code");

--- a/totalRP3_Extended/script/script_generation.lua
+++ b/totalRP3_Extended/script/script_generation.lua
@@ -965,6 +965,9 @@ function TRP3_API.script.runLuaScriptEffect(code, args, secured)
 
 	env["op"] = operand;
 
+	env["getVar"] = TRP3_API.script.varCheck;
+	env["setVar"] = TRP3_API.script.setVar;
+
 	-- Compile
 	local factory, errorMessage = loadstring(code, "Generated code");
 	if not factory then


### PR DESCRIPTION
Restricted scripts can now access variables.
- getVar(args, source, varName)
- setVar(args, source, varName, varValue)
[source : "w" for workflow, "o" for object or "c" for campaign]
[varName : the name of the variable as a string (ex : "my_variable")]

*I'm planning on adding a small wiki article to explain the restricted script available functions - while repeating warnings about performance and lack of clarity for other players.*