### PR TITLE
Issue #84 : TRP3_KILL arguments change for player kill

### DIFF
--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -596,7 +596,9 @@ You can browse their website for other people's creations and paste them here.]]
 	WO_PASTE = "Paste workflow content",
 	WO_PASTE_CONFIRM = "Replace this workflow content with the one you copied earlier?",
 	WO_EVENT_EX_LINKS = "Game event links",
-	WO_EVENT_EX_LINKS_TT = "Here you can link your workflows to game events.\nEach link can be conditioned.",
+	WO_EVENT_EX_LINKS_TT = [[Here you can link your workflows to game events. Each link can be conditioned.
+<\br>
+|cff00ff00[<a href="https://github.com/Ellypse/Total-RP-3-Extended/wiki/Total-RP-3-:-Extended-custom-events">Documentation on Extended custom events</a>]|r]],
 	WO_EVENT_EX_LINK = "Game event link",
 	WO_EVENT_EX_ADD = "Add event link",
 	WO_EVENT_EX_NO = "No event link",

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -596,9 +596,7 @@ You can browse their website for other people's creations and paste them here.]]
 	WO_PASTE = "Paste workflow content",
 	WO_PASTE_CONFIRM = "Replace this workflow content with the one you copied earlier?",
 	WO_EVENT_EX_LINKS = "Game event links",
-	WO_EVENT_EX_LINKS_TT = [[Here you can link your workflows to game events. Each link can be conditioned.
-<\br>
-|cff00ff00[<a href="https://github.com/Ellypse/Total-RP-3-Extended/wiki/Total-RP-3-:-Extended-custom-events">Documentation on Extended custom events</a>]|r]],
+	WO_EVENT_EX_LINKS_TT = "Here you can link your workflows to game events.\nEach link can be conditioned.",
 	WO_EVENT_EX_LINK = "Game event link",
 	WO_EVENT_EX_ADD = "Add event link",
 	WO_EVENT_EX_NO = "No event link",

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1415,15 +1415,7 @@ The list of possible events is fixed and depends on the type of the object (item
 
 You can link one event to only one workflow. But the same workflow can be linked to multiple events.]],
 
-	TU_EL_3_TEXT = [[|cff00ff00Game events|r are events triggered by the game when something happens.
 
-Each link you add will link a game event to a workflow. Each time the event occurs, the workflow will be executed.
-
-|cff00ff00You can add a condition to the link by Ctrl+click on it.|r The condition will have access to the event arguments to be tested.
-For example if you listen to the event of casting a spell, you will be able in the condition to test which spell is casted.
-
-|cffff9900There is a large list of game event, thus it wouldn't be for us to list them all in the add-on. We suggest you to consult webwite like wowwiki.
-http://wowwiki.wikia.com/wiki/Event_API]],
 
 	TU_EL_4_TEXT = [[|cff00ff00Game events|r are only available for campaigns, quests and quest steps.]],
 
@@ -1568,6 +1560,19 @@ You can also see the history of previous steps, in case you forget something.]],
 |rWhen that's the case, TRP will convert these effects into a less damaging form (for instance, the shouting will be converted to a personal text) until you decide to unblock them.
 
 |cff00ff00You can block/unblock effects and white-list effects or players by Alt + Right-click on an item on your inventory.]],
+
+	TU_EL_3_TEXT_V2 = [[|cff00ff00Game events|r are events triggered by the game when something happens.
+
+Each link you add will link a game event to a workflow. Each time the event occurs, the workflow will be executed.
+
+|cff00ff00You can add a condition to the link by Ctrl+click on it.|r The condition will have access to the event arguments to be tested.
+For example if you listen to the event of casting a spell, you will be able in the condition to test which spell is casted.
+
+|cffff9900There is a large list of game event, thus it wouldn't be for us to list them all in the add-on. We suggest you to consult webwite like wowwiki.
+http://wowwiki.wikia.com/wiki/Event_API
+
+|rIn addition to the game's events, |cff00ff00Total RP 3: Extended offers a couple of custom events|r detailed on the addon wiki.
+|cff00ff00https://github.com/Ellypse/Total-RP-3-Extended/wiki|r]],
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended/main.lua
+++ b/totalRP3_Extended/main.lua
@@ -460,7 +460,12 @@ local function onStart()
 		local time, event, _, source, sourceName, _, _, dest, destName = ...;
 		if event == "PARTY_KILL" then
 			local unitType, NPC_ID = Utils.str.getUnitDataFromGUIDDirect(dest);
-			Utils.event.fireEvent(TRP3_API.extended.KILL_EVENT, event, source, sourceName, dest, destName, NPC_ID);
+			if (unitType == "Player") then
+				local className, classID, raceName, raceID, gender = GetPlayerInfoByGUID(dest);
+				Utils.event.fireEvent(TRP3_API.extended.KILL_EVENT, unitType, source, sourceName, dest, destName, classID, className, raceID, raceName, gender);
+			else
+				Utils.event.fireEvent(TRP3_API.extended.KILL_EVENT, unitType, source, sourceName, dest, destName, NPC_ID);
+			end
 		end
 	end);
 end

--- a/totalRP3_Extended_Tools/links/links.lua
+++ b/totalRP3_Extended_Tools/links/links.lua
@@ -230,8 +230,16 @@ function editor.init(ToolFrame)
 	-- GAME
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-	gameLinksEditor.title:SetText(loc.WO_EVENT_EX_LINKS);
-	gameLinksEditor.help:SetText(loc.WO_EVENT_EX_LINKS_TT);
+	do
+		gameLinksEditor.title:SetText(loc.WO_EVENT_EX_LINKS);
+
+		---@type SimpleHTML
+		local helpInfo = gameLinksEditor.help;
+		helpInfo:SetText(HTML_START .. loc.WO_EVENT_EX_LINKS_TT .. HTML_END);
+		helpInfo:SetScript("OnHyperlinkClick", function(self, url)
+			TRP3_API.popup.showTextInputPopup(loc("UI_LINK_WARNING"), nil, nil, url);
+		end);
+	end
 
 	-- List
 	gameLinksEditor.list.widgetTab = {};

--- a/totalRP3_Extended_Tools/links/links.lua
+++ b/totalRP3_Extended_Tools/links/links.lua
@@ -230,16 +230,8 @@ function editor.init(ToolFrame)
 	-- GAME
 	--*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-	do
-		gameLinksEditor.title:SetText(loc.WO_EVENT_EX_LINKS);
-
-		---@type SimpleHTML
-		local helpInfo = gameLinksEditor.help;
-		helpInfo:SetText(HTML_START .. loc.WO_EVENT_EX_LINKS_TT .. HTML_END);
-		helpInfo:SetScript("OnHyperlinkClick", function(self, url)
-			TRP3_API.popup.showTextInputPopup(loc("UI_LINK_WARNING"), nil, nil, url);
-		end);
-	end
+	gameLinksEditor.title:SetText(loc.WO_EVENT_EX_LINKS);
+	gameLinksEditor.help:SetText(loc.WO_EVENT_EX_LINKS_TT);
 
 	-- List
 	gameLinksEditor.list.widgetTab = {};

--- a/totalRP3_Extended_Tools/links/links.lua
+++ b/totalRP3_Extended_Tools/links/links.lua
@@ -299,7 +299,7 @@ function editor.init(ToolFrame)
 			arrow = "RIGHT", x = 0, y = 0, anchor = "CENTER", textWidth = 400,
 		},
 		{
-			box = gameLinksEditor, title = "WO_EVENT_EX_LINKS", text = "TU_EL_3_TEXT",
+			box = gameLinksEditor, title = "WO_EVENT_EX_LINKS", text = "TU_EL_3_TEXT_V2",
 			arrow = "LEFT", x = 0, y = 0, anchor = "CENTER", textWidth = 400,
 		}
 	};

--- a/totalRP3_Extended_Tools/links/links.xml
+++ b/totalRP3_Extended_Tools/links/links.xml
@@ -174,23 +174,19 @@
 					<Anchor point="BOTTOM" x="0" y="5"/>
 				</Anchors>
 
-				<Layers>
-					<Layer level="OVERLAY">
-
-						<FontString parentKey="help" inherits="GameFontNormal" justifyH="CENTER" justifyV="MIDDLE" setAllPoints="true">
-							<Size x="0" y="75"/>
-							<Anchors>
-								<Anchor point="TOP" relativePoint="BOTTOM" relativeKey="$parent.title" x="0" y="0"/>
-								<Anchor point="RIGHT" x="-20" y="0"/>
-								<Anchor point="LEFT" x="20" y="0"/>
-							</Anchors>
+				<Frames>
+					<SimpleHTML parentKey="help">
+						<Size x="0" y="75"/>
+						<Anchors>
+							<Anchor point="TOP" relativePoint="BOTTOM" relativeKey="$parent.title" x="0" y="0"/>
+							<Anchor point="RIGHT" x="-20" y="0"/>
+							<Anchor point="LEFT" x="20" y="0"/>
+						</Anchors>
+						<FontString inherits="GameFontNormal" justifyH="CENTER" justifyV="MIDDLE" setAllPoints="true">
 							<Color r="0.95" g="0.95" b="0.95"/>
 						</FontString>
-
-					</Layer>
-				</Layers>
-
-				<Frames>
+					</SimpleHTML>
+					
 					<Frame parentKey="editor" inherits="TRP3_HoveredFrame" enableMouse="true" hidden="true">
 						<Size x="300" y="175"/>
 						<Layers>

--- a/totalRP3_Extended_Tools/links/links.xml
+++ b/totalRP3_Extended_Tools/links/links.xml
@@ -174,19 +174,23 @@
 					<Anchor point="BOTTOM" x="0" y="5"/>
 				</Anchors>
 
-				<Frames>
-					<SimpleHTML parentKey="help">
-						<Size x="0" y="75"/>
-						<Anchors>
-							<Anchor point="TOP" relativePoint="BOTTOM" relativeKey="$parent.title" x="0" y="0"/>
-							<Anchor point="RIGHT" x="-20" y="0"/>
-							<Anchor point="LEFT" x="20" y="0"/>
-						</Anchors>
-						<FontString inherits="GameFontNormal" justifyH="CENTER" justifyV="MIDDLE" setAllPoints="true">
+				<Layers>
+					<Layer level="OVERLAY">
+
+						<FontString parentKey="help" inherits="GameFontNormal" justifyH="CENTER" justifyV="MIDDLE" setAllPoints="true">
+							<Size x="0" y="75"/>
+							<Anchors>
+								<Anchor point="TOP" relativePoint="BOTTOM" relativeKey="$parent.title" x="0" y="0"/>
+								<Anchor point="RIGHT" x="-20" y="0"/>
+								<Anchor point="LEFT" x="20" y="0"/>
+							</Anchors>
 							<Color r="0.95" g="0.95" b="0.95"/>
 						</FontString>
-					</SimpleHTML>
-					
+
+					</Layer>
+				</Layers>
+
+				<Frames>
 					<Frame parentKey="editor" inherits="TRP3_HoveredFrame" enableMouse="true" hidden="true">
 						<Size x="300" y="175"/>
 						<Layers>


### PR DESCRIPTION
Changed TRP3_KILL arguments in the case of a player kill, so that it returns info on the player killed (class/race/gender).
Since TRP3_KILL wasn't documented, I added an article to the wiki detailing how this event (as well as TRP3_SIGNAL) work and linked to it in the in-game tutorial.

*I don't want to hear about HTML ever again.*