### PR TITLE
Issue #12 : "Loot all" effect fix

### DIFF
--- a/totalRP3_Extended/inventory/container.lua
+++ b/totalRP3_Extended/inventory/container.lua
@@ -1019,7 +1019,7 @@ function TRP3_API.inventory.initLootFrame()
 	lootAll:SetScript("OnClick", function()
 		for _, slot in pairs(lootFrame.slots) do
 			if slot.info then
-				pickUpLoot(slot);
+				doPickUpLoot(slot, nil, nil, slot.info.count or 1);
 			end
 		end
 	end);

--- a/totalRP3_Extended/inventory/inventory.lua
+++ b/totalRP3_Extended/inventory/inventory.lua
@@ -36,9 +36,11 @@ local QUICK_SLOT_ID = "17";
 TRP3_API.inventory.QUICK_SLOT_ID = QUICK_SLOT_ID;
 
 local function onItemAddEnd(container, itemClass, returnType, count, ...)
-	Utils.message.displayMessage(loc.IT_INV_GOT:format(getItemLink(itemClass), count));
-	TRP3_API.events.fireEvent(TRP3_API.inventory.EVENT_REFRESH_BAG, container);
-	TRP3_API.inventory.recomputeAllInventory();
+	if count ~= 0 then
+		Utils.message.displayMessage(loc.IT_INV_GOT:format(getItemLink(itemClass), count));
+		TRP3_API.events.fireEvent(TRP3_API.inventory.EVENT_REFRESH_BAG, container);
+		TRP3_API.inventory.recomputeAllInventory();
+	end
 	return returnType, count, ...;
 end
 


### PR DESCRIPTION
Loot all was stopping every time it encountered a stack, asking for how much stacks the player wanted to loot. Loot all doesn't ask anymore, trying to loot everything it can (and still stopping when it cannot loot anymore).
Small bonus fix : when it cannot loot anymore, it would show "Received [non-looted item] x0". I added a check so that the message (and the inventory refresh that goes with it) doesn't happen if we're adding 0 of an item.