### PR TITLE
Issues #22 & #74 : Changes regarding item creation modes

### DIFF
--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1574,6 +1574,8 @@ http://wowwiki.wikia.com/wiki/Event_API
 
 |rIn addition to the game's events, |cff00ff00Total RP 3: Extended offers a couple of custom events|r detailed on the addon wiki.
 |cff00ff00https://github.com/Ellypse/Total-RP-3-Extended/wiki|r]],
+	DR_STASHES_OWNERSHIP = "Take ownership",
+	DR_STASHES_OWNERSHIP_PP = "Take ownership of this stash?\nThis character will be shown as owner of this stash when other players scan for it.",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1568,6 +1568,8 @@ You can also see the history of previous steps, in case you forget something.]],
 |rWhen that's the case, TRP will convert these effects into a less damaging form (for instance, the shouting will be converted to a personal text) until you decide to unblock them.
 
 |cff00ff00You can block/unblock effects and white-list effects or players by Alt + Right-click on an item on your inventory.]],
+	DB_CREATE_ITEM_TEMPLATES_EXPERT = "Expert item",
+	DB_CREATE_ITEM_TEMPLATES_EXPERT_TT = "An expert blank template.\nFor users with experience making creations.",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended_Tools/inner/inner.lua
+++ b/totalRP3_Extended_Tools/inner/inner.lua
@@ -37,7 +37,7 @@ editor.browser.container.lines = {};
 -- Inner object editor: Logic
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 
-local function createInnerObject(innerID, innerType, innerData)
+local function createInnerObject(innerID, innerType, innerMode, innerData)
 	assert(toolFrame.specificDraft.IN, "No toolFrame.specificDraft.IN for refresh.");
 	assert(innerID and innerID:len() > 0, "Bad inner ID");
 
@@ -56,6 +56,10 @@ local function createInnerObject(innerID, innerType, innerData)
 				NA = loc.IT_NEW_NAME,
 			},
 		}
+
+		if innerMode then
+			toolFrame.specificDraft.IN[innerID].MD.MO = innerMode;
+		end
 	elseif innerType == TRP3_DB.types.DOCUMENT then
 		toolFrame.specificDraft.IN[innerID] = innerData or {
 			TY = TRP3_DB.types.DOCUMENT,
@@ -221,13 +225,22 @@ end
 
 local function addInnerObject(type, self)
 	assert(toolFrame.specificDraft.IN, "No toolFrame.specificDraft.IN for refresh.");
+	-- Checking the parent mode to automatically adapt the mode for inner items
+	local parentClass = getClass(toolFrame.fullClassID);
+	local parentMode = (parentClass.MD and parentClass.MD.MO);
+	local innerMode;
+	if (parentMode == TRP3_DB.modes.EXPERT) then
+		innerMode = TRP3_DB.modes.EXPERT;
+	else
+		innerMode = TRP3_DB.modes.NORMAL;
+	end
 	TRP3_API.popup.showTextInputPopup(loc.IN_INNER_ENTER_ID .. "\n\n" .. loc.IN_INNER_ENTER_ID_TT, function(innerID)
 		if not innerID or innerID:len() == 0 then
 			return;
 		elseif innerID:find(" ") then
 			TRP3_API.popup.showAlertPopup(loc.IN_INNER_ENTER_ID_NO_SPACE);
 		elseif self == editor.browser.add then
-			createInnerObject(innerID, type);
+			createInnerObject(innerID, type, innerMode);
 			refresh();
 		elseif self == editor.browser.addcopy then
 			TRP3_API.popup.showPopup(TRP3_API.popup.OBJECTS, {parent = editor, point = "CENTER", parentPoint = "CENTER"}, {function(id)
@@ -235,7 +248,7 @@ local function addInnerObject(type, self)
 				local template = {};
 				Utils.table.copy(template, class);
 				TRP3_API.extended.tools.replaceID(template, id, toolFrame.fullClassID .. TRP3_API.extended.ID_SEPARATOR .. innerID);
-				createInnerObject(innerID, type, template);
+				createInnerObject(innerID, type, innerMode, template);
 				refresh();
 			end, type});
 		end

--- a/totalRP3_Extended_Tools/inner/inner.lua
+++ b/totalRP3_Extended_Tools/inner/inner.lua
@@ -229,22 +229,29 @@ local function addInnerObject(type, self)
 	local parentClass = getClass(toolFrame.fullClassID);
 	local parentMode = (parentClass.MD and parentClass.MD.MO);
 	local innerMode;
-	if (parentMode == TRP3_DB.modes.EXPERT) then
-		innerMode = TRP3_DB.modes.EXPERT;
-	else
-		innerMode = TRP3_DB.modes.NORMAL;
-	end
 	TRP3_API.popup.showTextInputPopup(loc.IN_INNER_ENTER_ID .. "\n\n" .. loc.IN_INNER_ENTER_ID_TT, function(innerID)
 		if not innerID or innerID:len() == 0 then
 			return;
 		elseif innerID:find(" ") then
 			TRP3_API.popup.showAlertPopup(loc.IN_INNER_ENTER_ID_NO_SPACE);
 		elseif self == editor.browser.add then
+			if (parentMode == TRP3_DB.modes.EXPERT) then
+				innerMode = TRP3_DB.modes.EXPERT;
+			else
+				innerMode = TRP3_DB.modes.NORMAL;
+			end
 			createInnerObject(innerID, type, innerMode);
 			refresh();
 		elseif self == editor.browser.addcopy then
 			TRP3_API.popup.showPopup(TRP3_API.popup.OBJECTS, {parent = editor, point = "CENTER", parentPoint = "CENTER"}, {function(id)
 				local class = getClass(id);
+				local sourceMode = (class.MD and class.MD.MO);
+				-- We don't want to convert an expert item to a normal item during copy.
+				if (parentMode == TRP3_DB.modes.EXPERT or sourceMode == TRP3_DB.modes.EXPERT) then
+					innerMode = TRP3_DB.modes.EXPERT;
+				else
+					innerMode = TRP3_DB.modes.NORMAL;
+				end
 				local template = {};
 				Utils.table.copy(template, class);
 				TRP3_API.extended.tools.replaceID(template, id, toolFrame.fullClassID .. TRP3_API.extended.ID_SEPARATOR .. innerID);

--- a/totalRP3_Extended_Tools/items/editor/quick.lua
+++ b/totalRP3_Extended_Tools/items/editor/quick.lua
@@ -252,6 +252,8 @@ function TRP3_API.extended.tools.initItemQuickEditor(ToolFrame)
 	toolFrame.list.bottom.item.templates.document.InfoText:SetText(loc.DB_CREATE_ITEM_TEMPLATES_DOCUMENT_TT);
 	toolFrame.list.bottom.item.templates.blank.Name:SetText(loc.DB_CREATE_ITEM_TEMPLATES_BLANK);
 	toolFrame.list.bottom.item.templates.blank.InfoText:SetText(loc.DB_CREATE_ITEM_TEMPLATES_BLANK_TT);
+	toolFrame.list.bottom.item.templates.expert.Name:SetText(loc.DB_CREATE_ITEM_TEMPLATES_EXPERT);
+	toolFrame.list.bottom.item.templates.expert.InfoText:SetText(loc.DB_CREATE_ITEM_TEMPLATES_EXPERT_TT);
 	toolFrame.list.bottom.item.templates.container.Name:SetText(loc.DB_CREATE_ITEM_TEMPLATES_CONTAINER);
 	toolFrame.list.bottom.item.templates.container.InfoText:SetText(loc.DB_CREATE_ITEM_TEMPLATES_CONTAINER_TT);
 	toolFrame.list.bottom.item.templates.from.Name:SetText(loc.DB_CREATE_ITEM_TEMPLATES_FROM);
@@ -264,6 +266,7 @@ function TRP3_API.extended.tools.initItemQuickEditor(ToolFrame)
 
 	TRP3_API.ui.frame.setupIconButton(toolFrame.list.bottom.item.templates.container, "inv_misc_bag_36");
 	TRP3_API.ui.frame.setupIconButton(toolFrame.list.bottom.item.templates.blank, "inv_inscription_scroll");
+	TRP3_API.ui.frame.setupIconButton(toolFrame.list.bottom.item.templates.expert, "ability_siege_engineer_pattern_recognition");
 	TRP3_API.ui.frame.setupIconButton(toolFrame.list.bottom.item.templates.document, "inv_misc_book_16");
 	TRP3_API.ui.frame.setupIconButton(toolFrame.list.bottom.item.templates.quick, "petbattle_speed");
 	TRP3_API.ui.frame.setupIconButton(toolFrame.list.bottom.item.templates.from, "spell_nature_mirrorimage");
@@ -279,6 +282,8 @@ function TRP3_API.extended.tools.initItemQuickEditor(ToolFrame)
 			self.templates:Hide();
 		else
 			TRP3_API.ui.frame.configureHoverFrame(self.templates, self, "BOTTOM", 0, 5, false);
+			self.templates:SetPoint("BOTTOM", self, "TOP", 200, 25);	-- Black magic to off-center the templates frame.
+			self.templates.ArrowUP:SetPoint("TOP", self.templates, "BOTTOM", -200, 5);	-- More black magic to re-center the arrow on the button.
 		end
 	end);
 
@@ -298,6 +303,12 @@ function TRP3_API.extended.tools.initItemQuickEditor(ToolFrame)
 	toolFrame.list.bottom.item.templates.blank:SetScript("OnClick", function()
 		toolFrame.list.bottom.item.templates:Hide();
 		local ID, _ = TRP3_API.extended.tools.createItem(TRP3_API.extended.tools.getBlankItemData(TRP3_DB.modes.NORMAL));
+		TRP3_API.extended.tools.goToPage(ID);
+	end);
+
+	toolFrame.list.bottom.item.templates.expert:SetScript("OnClick", function()
+		toolFrame.list.bottom.item.templates:Hide();
+		local ID, _ = TRP3_API.extended.tools.createItem(TRP3_API.extended.tools.getBlankItemData(TRP3_DB.modes.EXPERT));
 		TRP3_API.extended.tools.goToPage(ID);
 	end);
 

--- a/totalRP3_Extended_Tools/items/editor/quick.xml
+++ b/totalRP3_Extended_Tools/items/editor/quick.xml
@@ -24,7 +24,7 @@
 	<!-- *_*_*_*_*_*_*_*_*_*  -->
 
 	<Frame name="TRP3_ItemTemplates" inherits="TRP3_AltHoveredFrame" enableMouse="true" virtual="true">
-		<Size x="450" y="450"/>
+		<Size x="800" y="380"/>
 		<Frames>
 			<Button parentKey="quick" inherits="TRP3_QuestButtonTemplate">
 				<Anchors>
@@ -36,19 +36,24 @@
 					<Anchor point="TOPLEFT" x="50" y="-145"/>
 				</Anchors>
 			</Button>
-			<Button parentKey="document" inherits="TRP3_QuestButtonTemplate">
+			<Button parentKey="expert" inherits="TRP3_QuestButtonTemplate">
 				<Anchors>
-					<Anchor point="TOPLEFT" x="50" y="-215"/>
+					<Anchor point="TOPLEFT" x="400" y="-145"/>
 				</Anchors>
 			</Button>
 			<Button parentKey="container" inherits="TRP3_QuestButtonTemplate">
 				<Anchors>
-					<Anchor point="TOPLEFT" x="50" y="-285"/>
+					<Anchor point="TOPLEFT" x="50" y="-215"/>
+				</Anchors>
+			</Button>
+			<Button parentKey="document" inherits="TRP3_QuestButtonTemplate">
+				<Anchors>
+					<Anchor point="TOPLEFT" x="400" y="-215"/>
 				</Anchors>
 			</Button>
 			<Button parentKey="from" inherits="TRP3_QuestButtonTemplate">
 				<Anchors>
-					<Anchor point="TOPLEFT" x="50" y="-355"/>
+					<Anchor point="TOPLEFT" x="50" y="-285"/>
 				</Anchors>
 			</Button>
 		</Frames>


### PR DESCRIPTION
- Added a button in the item templates to create a blank expert item.
- Changed the item templates buttons layout so the height wouldn't get crazy.
- To both simplify the conversion to expert mode for inner items and solve the bug when copying quick items, inner items will now automatically set their mode to the same as their parent (exception : if the source item is expert and the parent is normal, the inner item will stay expert).