### PR TITLE
Issue #27 : Store dice roll result in a variable

### DIFF
--- a/totalRP3_Extended/inventory/inventory_effects.lua
+++ b/totalRP3_Extended/inventory/inventory_effects.lua
@@ -155,11 +155,17 @@ TRP3_API.inventory.EFFECTS = {
 		getCArgs = function(args)
 			local roll = tostring(args[1]) or "1d100";
 			local serial = strjoin("\", args), var(\"", strsplit(" ", roll));
-			return serial;
+			local varName = args[2] or "";
+			local varSource = args[3] or "w";
+			return serial, varName, varSource;
 		end,
 		method = function(structure, cArgs, eArgs)
-			local serial = structure.getCArgs(cArgs);
-			eArgs.LAST = TRP3_API.slash.rollDices(strsplit(" ",TRP3_API.script.parseArgs(serial, eArgs)));
+			local serial, varName, varSource = structure.getCArgs(cArgs);
+			local rollResult = TRP3_API.slash.rollDices(strsplit(" ",TRP3_API.script.parseArgs(serial, eArgs)));
+			if varName ~= "" then
+				TRP3_API.script.setVar(eArgs, varSource, "=", varName, rollResult);
+			end
+			eArgs.LAST = rollResult;
 		end,
 	},
 

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1574,6 +1574,9 @@ http://wowwiki.wikia.com/wiki/Event_API
 |cff00ff00https://github.com/Ellypse/Total-RP-3-Extended/wiki|r]],
 	DR_STASHES_OWNERSHIP = "Take ownership",
 	DR_STASHES_OWNERSHIP_PP = "Take ownership of this stash?\nThis character will be shown as owner of this stash when other players scan for it.",
+	EFFECT_ITEM_DICE_PREVIEW_STORED = "Rollin' %s and saving the result to %s",
+	EFFECT_ITEM_DICE_ROLL_VAR = "Variable name (optional)",
+	EFFECT_ITEM_DICE_ROLL_VAR_TT = "The variable in which you want to store the dice roll result.\nLeave empty if you don't want to store the result.",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended_Tools/items/effects.lua
+++ b/totalRP3_Extended_Tools/items/effects.lua
@@ -328,24 +328,50 @@ local function item_roll_dice_init()
 	editor.roll.title:SetText(loc.EFFECT_ITEM_DICE_ROLL);
 	setTooltipForSameFrame(editor.roll.help, "RIGHT", 0, 5, loc.EFFECT_ITEM_DICE_ROLL, loc.EFFECT_ITEM_DICE_ROLL_TT);
 
+	editor.var.title:SetText(loc.EFFECT_ITEM_DICE_ROLL_VAR);
+	setTooltipForSameFrame(editor.var.help, "RIGHT", 0, 5, loc.EFFECT_ITEM_DICE_ROLL_VAR, loc.EFFECT_ITEM_DICE_ROLL_VAR_TT);
+
+	-- Source
+	local sources = {
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_SOURCE, loc.EFFECT_SOURCE_WORKFLOW), "w", loc.EFFECT_SOURCE_WORKFLOW_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_SOURCE, loc.EFFECT_SOURCE_OBJECT), "o", loc.EFFECT_SOURCE_OBJECT_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_SOURCE, loc.EFFECT_SOURCE_CAMPAIGN), "c", loc.EFFECT_SOURCE_CAMPAIGN_TT}
+	}
+	TRP3_API.ui.listbox.setupListBox(editor.source, sources, nil, nil, 250, true);
+
 	function editor.load(scriptData)
 		local data = scriptData.args or Globals.empty;
 		editor.roll:SetText(data[1] or "1d100");
+		editor.var:SetText(data[2] or "");
+		editor.source:SetSelectedValue(data[3] or "w");
 	end
 
 	function editor.save(scriptData)
 		scriptData.args[1] = stEtN(strtrim(editor.roll:GetText())) or "1d100";
+		scriptData.args[2] = stEtN(strtrim(editor.var:GetText())) or "";
+		scriptData.args[3] = editor.source:GetSelectedValue() or "w";
 	end
+
+	local sourcesText = {
+		w = loc.EFFECT_SOURCE_WORKFLOW,
+		o = loc.EFFECT_SOURCE_OBJECT,
+		c = loc.EFFECT_SOURCE_CAMPAIGN
+	}
 
 	registerEffectEditor("item_roll_dice", {
 		title = loc.EFFECT_ITEM_DICE,
 		icon = "inv_misc_dice_02",
 		description = loc.EFFECT_ITEM_DICE_TT,
 		effectFrameDecorator = function(scriptStepFrame, args)
-			scriptStepFrame.description:SetText(loc.EFFECT_ITEM_DICE_PREVIEW:format("|cff00ff00" .. tostring(args[1]) .. "|r"));
+			if args[2] ~= "" then
+				local source = sourcesText[args[3]] or "?";
+				scriptStepFrame.description:SetText(loc.EFFECT_ITEM_DICE_PREVIEW_STORED:format(TRP3_API.Ellyb.ColorManager.GREEN(tostring(args[1])), TRP3_API.Ellyb.ColorManager.GREEN("(" .. source .. ") ") .. tostring(args[2])));
+			else
+				scriptStepFrame.description:SetText(loc.EFFECT_ITEM_DICE_PREVIEW:format(TRP3_API.Ellyb.ColorManager.GREEN(tostring(args[1]))));
+			end
 		end,
 		getDefaultArgs = function()
-			return {"1d100", ""};
+			return {"1d100", "", "w"};
 		end,
 		editor = editor,
 	});

--- a/totalRP3_Extended_Tools/items/items.xml
+++ b/totalRP3_Extended_Tools/items/items.xml
@@ -215,6 +215,19 @@
 				</Anchors>
 			</EditBox>
 
+			<EditBox parentKey="var" inherits="TRP3_TitledHelpEditBox">
+				<Size x="260" y="18"/>
+				<Anchors>
+					<Anchor point="TOP" relativePoint="BOTTOM" relativeKey="$parent.roll" x="0" y="-25"/>
+				</Anchors>
+			</EditBox>
+
+			<Frame parentKey="source" inherits="UIDropDownMenuTemplate" enableMouse="true" name="$parentSource">
+				<Anchors>
+					<Anchor point="TOPLEFT" relativePoint="BOTTOMLEFT" relativeKey="$parent.var" x="-20" y="-20"/>
+				</Anchors>
+			</Frame>
+
 		</Frames>
 
 	</Frame>


### PR DESCRIPTION
Added fields to enter a variable name & source to the dice roll effect editor. If empty, the roll works as it currently does. Else, it will (shockingly) store the dice roll result in the given variable.