### PR TITLE
Removed debug inspect table

### DIFF
--- a/totalRP3_Extended_Tools/list/list.lua
+++ b/totalRP3_Extended_Tools/list/list.lua
@@ -129,7 +129,6 @@ local function onLineClick(self, button)
 	else
 		-- If the shift key is down we want to insert a link for this item
 		if IsShiftKeyDown() then
-			TRP3_API.Ellyb.Tables.inspect(data);
 			if data.type == "IT" then
 				TRP3_API.ChatLinks:OpenMakeImportablePrompt(loc.CL_EXTENDED_ITEM, function(canBeImported)
 					TRP3_API.extended.ItemsChatLinksModule:InsertLink(data.fullID, data.rootID, {}, canBeImported);


### PR DESCRIPTION
When shift-clicking from the database to create a link, there was a debug instruction left to inspect the data table, I tracked it down and removed it.
Also merge my dice roll PR 😡 