### PR TITLE
A couple of minor fixes

### DIFF
--- a/totalRP3_Extended/dialogues/dialogues.xml
+++ b/totalRP3_Extended/dialogues/dialogues.xml
@@ -53,9 +53,9 @@
 					<Anchor point="CENTER" relativePoint="LEFT" x="0" y="0" />
 				</Anchors>
 				<Scripts>
-					<OnMouseDown function="nil"/>
-					<OnMouseUp function="nil"/>
-					<OnClick function="nil"/>
+					<OnMouseDown function=""/>
+					<OnMouseUp function=""/>
+					<OnClick function=""/>
 				</Scripts>
 			</Button>
 		</Frames>

--- a/totalRP3_Extended/document/document.xml
+++ b/totalRP3_Extended/document/document.xml
@@ -100,7 +100,6 @@
 		</Frames>
 	</Frame>
 
-	<Script file="db.lua"/>
 	<Script file="document.lua"/>
 
 </Ui>

--- a/totalRP3_Extended/inventory/inventory.xml
+++ b/totalRP3_Extended/inventory/inventory.xml
@@ -383,15 +383,15 @@
 							<Anchor point="RIGHT" x="-5" y="0"/>
 						</Anchors>
 						<Scripts>
-							<OnEnter function="nil"/>
-							<OnLeave function="nil"/>
+							<OnEnter function=""/>
+							<OnLeave function=""/>
 							<OnMouseUp>
 								self.onMouseUpFunc(self, button);
 							</OnMouseUp>
 							<OnMouseDown>
 								Model_OnMouseDown(self, button);
 							</OnMouseDown>
-							<OnMouseWheel function="nil"/>
+							<OnMouseWheel function=""/>
 						</Scripts>
 						<Layers>
 							<Layer level="OVERLAY">

--- a/totalRP3_Extended/misc/cast.xml
+++ b/totalRP3_Extended/misc/cast.xml
@@ -28,8 +28,8 @@
 			<OnLoad>
 				CastingBarFrame_OnLoad(self, nil, false, false);
 			</OnLoad>
-			<OnEvent function="nil" />
-			<OnShow function="nil" />
+			<OnEvent function="" />
+			<OnShow function="" />
 		</Scripts>
 	</StatusBar>
 


### PR DESCRIPTION
- Some templates copied from Blizzard had their event functions replaced by "nil" which threw an error on load, since "nil" isn't a function. I replaced them with an empty string, which doesn't throw an error.
- There was a reference to a db.lua file that doesn't exist in the document folder (and shouldn't exist, as documents can't be creations by themselves)