### PR TITLE
Changes to version number display + small typo fix

### DIFF
--- a/totalRP3_Extended/inventory/container.lua
+++ b/totalRP3_Extended/inventory/container.lua
@@ -163,7 +163,7 @@ local function getItemTooltipLines(slotInfo, class, forceAlt)
 				end
 				if not rootClass.MD.tV or rootClass.MD.tV < Globals.extended_version then
 					text2 = text2 .. "\n\n";
-					text2 = text2 .. color("o") .. loc.SET_TT_OLD:format(rootClass.MD.tV ~= nil and TRP3_API.extended.tools.formatVersion(rootClass.MD.tV) or "?");
+					text2 = text2 .. color("o") .. loc.SET_TT_OLD:format(TRP3_API.extended.tools.getClassVersion(rootClass));
 				end
 			end
 		end

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1737,7 +1737,7 @@ Created by |cff00ff00Sylvain "Telkostrasz" Cossement|r and |cff00ff00Renaud "Ell
 
 ##  You are the best!
 
-## Total RP 3: Extended is also maintained thanks Ellype's [Patreon](http://patreon.com/Ellypse) supporters:
+## Total RP 3: Extended is also maintained thanks to Ellypse's [Patreon](http://patreon.com/Ellypse) supporters:
 
 %s
 ]];

--- a/totalRP3_Extended/main.lua
+++ b/totalRP3_Extended/main.lua
@@ -478,7 +478,7 @@ local function onStart()
 end
 
 Globals.extended_version = 1012;
-Globals.extended_display_version = "1.1.1";
+Globals.extended_display_version = "@project-version@";
 
 local MODULE_STRUCTURE = {
 	["name"] = "Extended",

--- a/totalRP3_Extended/main.lua
+++ b/totalRP3_Extended/main.lua
@@ -478,6 +478,7 @@ local function onStart()
 end
 
 Globals.extended_version = 1012;
+Globals.extended_display_version = "1.1.1";
 
 local MODULE_STRUCTURE = {
 	["name"] = "Extended",

--- a/totalRP3_Extended_Tools/main.lua
+++ b/totalRP3_Extended_Tools/main.lua
@@ -237,6 +237,7 @@ local function doSave()
 	object.MD.SD = date("%d/%m/%y %H:%M:%S");
 	object.MD.SB = Globals.player_id;
 	object.MD.tV = Globals.extended_version;
+	object.MD.dV = Globals.extended_display_version;
 
 	TRP3_API.security.computeSecurity(rootClassID, object);
 	TRP3_API.extended.unregisterObject(rootClassID);


### PR DESCRIPTION
Soooo, changes to compensate for the build/version number shenanigans.

- Added the version number in the globals (extended_display_version)
- Added a field "dV" (for display version) in the creations. This field is used to display the version number if present, else it tries to format the build number.
- Version formatting function has cases for the 3 decoupled versions.
- Changed import/export functions to keep track of the version number as well. Tested exporting/importing through wago for cases with and without the version number, no issue.

I also fixed a small typo while I was at it, didn't want to branch just for this.

We could use the version number instead of the build number in the TRP modules list, depending on your opinion.