### PR TITLE
Random battle pet summon now allows to pull from favourites only

### DIFF
--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -660,7 +660,6 @@ The function is in the form of:
 	EFFECT_DISPET = "Dismiss battle pet",
 	EFFECT_DISPET_TT = "Dismiss the currently invoked battle pet.",
 	EFFECT_RANDSUM = "Summon random battle pet",
-	EFFECT_RANDSUM_TT = "Summon a random battle pet, picked up in your favorite pets pool.",
 	EFFECT_SUMMOUNT = "Summon a mount",
 	EFFECT_SUMMOUNT_TT = "Summon a specific mount, if available.",
 	EFFECT_SUMMOUNT_NOMOUNT = "No mount select yet.",
@@ -1591,6 +1590,10 @@ http://wowwiki.wikia.com/wiki/Event_API
 	--- THEN MOVE IT UP ONCE IMPORTED
 	------------------------------------------------------------------------------------------------
 
+	EFFECT_RANDSUM_TT = "Summon a random battle pet.",
+	EFFECT_RANDSUM_SUMMON_FAV = "Only summon favourite pets",
+	EFFECT_RANDSUM_PREVIEW_FULL = "Summon a random battle pet from your |c0000ff00entire pool|r.",
+	EFFECT_RANDSUM_PREVIEW_FAV = "Summon a random battle pet from your |c0000ff00favourite pool|r.",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -354,8 +354,13 @@ local EFFECTS = {
 	},
 
 	["companion_random_critter"] = {
+		getCArgs = function(args)
+			local summonFav = args[1] or false;
+			return summonFav;
+		end,
 		method = function(structure, cArgs, eArgs)
-			C_PetJournal.SummonRandomPet();
+			local summonFav = structure.getCArgs(cArgs);
+			C_PetJournal.SummonRandomPet(summonFav);
 			eArgs.LAST = 0;
 		end,
 		secured = security.HIGH,

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -150,11 +150,35 @@ local function companion_dismiss_critter_init()
 end
 
 local function companion_random_critter_init()
+	local editor = TRP3_EffectEditorSummonPet;
+
 	registerEffectEditor("companion_random_critter", {
 		title = loc.EFFECT_RANDSUM,
 		icon = "ability_hunter_beastcall",
 		description = loc.EFFECT_RANDSUM_TT,
+		effectFrameDecorator = function(scriptStepFrame, args)
+			if args and args[1] then
+				scriptStepFrame.description:SetText(loc.EFFECT_RANDSUM_PREVIEW_FAV);
+			else
+				scriptStepFrame.description:SetText(loc.EFFECT_RANDSUM_PREVIEW_FULL);
+			end
+		end,
+		getDefaultArgs = function()
+			return {false};
+		end,
+		editor = editor
 	});
+
+	editor.favourite.Text:SetText(loc.EFFECT_RANDSUM_SUMMON_FAV);
+
+	function editor.load(scriptData)
+		local data = scriptData.args or Globals.empty;
+		editor.favourite:SetChecked(data[1] or false);
+	end
+
+	function editor.save(scriptData)
+		scriptData.args[1] = editor.favourite:GetChecked();
+	end
 end
 
 local function companion_summon_mount_init()

--- a/totalRP3_Extended_Tools/script/effects/effects.xml
+++ b/totalRP3_Extended_Tools/script/effects/effects.xml
@@ -500,6 +500,19 @@
 
 	</Frame>
 
+	<Frame name="TRP3_EffectEditorSummonPet" hidden="true" inherits="TRP3_EditorEffectTemplate">
+		<Size x="500" y="180"/>
+		<Frames>
+			<CheckButton parentKey="favourite" inherits="TRP3_CheckBox" name="$parentFavourite">
+				<Anchors>
+					<Anchor point="LEFT" x="50"/>
+				</Anchors>
+			</CheckButton>
+
+		</Frames>
+
+	</Frame>
+
 	<!-- *_*_*_*_*_*_*_*_*_*  -->
 	<!--    Script       -->
 	<!-- *_*_*_*_*_*_*_*_*_*  -->


### PR DESCRIPTION
While testing all effects, I stumbled upon a mistake : the "Summon random pet" effect said it was pulling from the favourite pets pool in the tooltip, but the effect was actually pulling from the entire pool.

Instead of only correcting the tooltip, I changed the effect to allow for summoning from either the entire pool or the favourite pool.