### PR TITLE
Summon random favourite mount

### DIFF
--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -663,7 +663,6 @@ The function is in the form of:
 	EFFECT_RANDSUM_TT = "Summon a random battle pet, picked up in your favorite pets pool.",
 	EFFECT_SUMMOUNT = "Summon a mount",
 	EFFECT_SUMMOUNT_TT = "Summon a specific mount, if available.",
-	EFFECT_SUMMOUNT_NOMOUNT = "No mount select yet.",
 	EFFECT_SHEATH = "Toggle weapons sheath",
 	EFFECT_SHEATH_TT = "Draw or put up the character weapons.",
 	EFFECT_VAR_OBJECT_CHANGE = "Variable operation",
@@ -1591,6 +1590,7 @@ http://wowwiki.wikia.com/wiki/Event_API
 	--- THEN MOVE IT UP ONCE IMPORTED
 	------------------------------------------------------------------------------------------------
 
+	EFFECT_SUMMOUNT_RANDOMMOUNT = "Random favourite",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -173,17 +173,23 @@ local function companion_summon_mount_init()
 		editor.id = data[1];
 		local creatureName, spellID, icon = GetMountInfoByID(editor.id or 0);
 		local _, description = GetMountInfoExtraByID(editor.id or 0);
-		companionSelected({creatureName or loc.EFFECT_SUMMOUNT_NOMOUNT, icon or "Interface\\ICONS\\inv_misc_questionmark", description or "", loc.PR_CO_MOUNT, spellID, editor.id});
+		companionSelected({creatureName or loc.EFFECT_SUMMOUNT_RANDOMMOUNT, icon or "Interface\\ICONS\\inv_misc_questionmark", description or "", loc.PR_CO_MOUNT, spellID, editor.id});
 	end
 
 	editor.save = function(scriptData)
 		scriptData.args[1] = editor.id or 0;
 	end
 
-	editor.select:SetScript("OnClick", function(self)
-		TRP3_API.popup.showPopup(TRP3_API.popup.COMPANIONS, {parent = self, point = "RIGHT", parentPoint = "LEFT"}, {companionSelected, nil, editor.type});
+	editor.select:SetScript("OnClick", function(self, button)
+		if button == "RightButton" then
+			companionSelected({loc.EFFECT_SUMMOUNT_RANDOMMOUNT, "Interface\\ICONS\\inv_misc_questionmark", "", loc.PR_CO_MOUNT, 0, 0});
+		else
+			TRP3_API.popup.showPopup(TRP3_API.popup.COMPANIONS, {parent = self, point = "RIGHT", parentPoint = "LEFT"}, {companionSelected, nil, editor.type});
+		end
 	end);
 	editor.type = TRP3_API.ui.misc.TYPE_MOUNT;
+
+	editor.select:RegisterForClicks("LeftButtonUp", "RightButtonUp");
 
 	registerEffectEditor("companion_summon_mount", {
 		title = loc.EFFECT_SUMMOUNT,
@@ -191,7 +197,7 @@ local function companion_summon_mount_init()
 		description = loc.EFFECT_SUMMOUNT_TT,
 		effectFrameDecorator = function(scriptStepFrame, args)
 			local creatureName = GetMountInfoByID(args[1] or 0);
-			scriptStepFrame.description:SetText("|cffffff00" ..loc.EFFECT_SUMMOUNT .. ":|r " .. tostring(creatureName or loc.EFFECT_SUMMOUNT_NOMOUNT));
+			scriptStepFrame.description:SetText("|cffffff00" ..loc.EFFECT_SUMMOUNT .. ":|r " .. tostring(creatureName or loc.EFFECT_SUMMOUNT_RANDOMMOUNT));
 		end,
 		getDefaultArgs = function()
 			return {0};


### PR DESCRIPTION
It was already possible to summon a random favourite mount, but it wasn't obvious (happened when you didn't set a mount) and you couldn't set it again after selecting a mount (other than deleting the effect and doing it again).

Right-clicking on the icon now removes the selected mount, and the "No mount selected" indicator has been replaced to indicate the effect will summon a random favourite mount. As far as I know, there is no option to summon a random mount from the entire pool.