### PR TITLE
Minor fixes

### DIFF
--- a/totalRP3_Extended/inventory/db.lua
+++ b/totalRP3_Extended/inventory/db.lua
@@ -134,9 +134,10 @@ TRP3_DB.inner.rifle = {
 							["cond"] = {
 								{
 									{
-										["i"] = "inv_item_count_con",
+										["i"] = "inv_item_count",
 										["a"] = {
 											"rifle bullet", -- [1]
+											"self", -- [2]
 										},
 									}, -- [1]
 									">", -- [2]

--- a/totalRP3_Extended/misc/sounds.lua
+++ b/totalRP3_Extended/misc/sounds.lua
@@ -18,7 +18,6 @@
 
 local Globals, Comm, Utils = TRP3_API.globals, TRP3_API.communication, TRP3_API.utils;
 local pairs, strsplit, floor, sqrt, tonumber = pairs, strsplit, math.floor, sqrt, tonumber;
-local EJ_GetCurrentInstance = EJ_GetCurrentInstance;
 local getConfigValue = TRP3_API.configuration.getValue;
 local loc = TRP3_API.loc;
 local Log = TRP3_API.utils.log;
@@ -34,7 +33,7 @@ local LOCAL_STOPSOUND_COMMAND = "STS";
 
 local function getPosition()
 	local posY, posX, posZ, instanceID = UnitPosition("player");
-	instanceID = instanceID	.. ',' .. EJ_GetCurrentInstance();
+	instanceID = instanceID;
 	posY = floor(posY + 0.5);
 	posX = floor(posX + 0.5);
 	return posY, posX, posZ, instanceID;
@@ -89,7 +88,7 @@ local function initSharedSound()
 				else
 					-- Get current position
 					local myPosY, myPosX, myPosZ, myInstanceID = UnitPosition("player");
-					myInstanceID = myInstanceID	.. ',' .. EJ_GetCurrentInstance();
+					myInstanceID = myInstanceID;
 					myPosY = floor(myPosY + 0.5);
 					myPosX = floor(myPosX + 0.5);
 

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -246,7 +246,7 @@ local EFFECTS = {
 
 	["sound_id_stop"] = {
 		getCArgs = function(args)
-			local soundID = tonumber(args[2] or nil);
+			local soundID = tonumber(args[2] or 0);
 			local channel = args[1] or "SFX";
 			return soundID, channel;
 		end,
@@ -294,7 +294,7 @@ local EFFECTS = {
 
 	["sound_id_local_stop"] = {
 		getCArgs = function(args)
-			local soundID = tonumber(args[2] or nil);
+			local soundID = tonumber(args[2] or 0);
 			local channel = args[1] or "SFX";
 			return soundID, channel;
 		end,

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -664,18 +664,21 @@ local function sound_id_self_init()
 
 	SoundIDSelfEditor.play:SetText(loc.EFFECT_SOUND_PLAY);
 	SoundIDSelfEditor.play:SetScript("OnClick", function(self)
-		Utils.music.playSoundID(tonumber(strtrim(SoundIDSelfEditor.id:GetText())), SoundIDSelfEditor.channel:GetSelectedValue() or "SFX");
+		local soundID = tonumber(strtrim(SoundIDSelfEditor.id:GetText()));
+		if soundID then
+			Utils.music.playSoundID(soundID, SoundIDSelfEditor.channel:GetSelectedValue() or "SFX");
+		end
 	end);
 
 	function SoundIDSelfEditor.load(scriptData)
 		local data = scriptData.args or Globals.empty;
 		SoundIDSelfEditor.channel:SetSelectedValue(data[1] or "SFX");
-		SoundIDSelfEditor.id:SetText(data[2]);
+		SoundIDSelfEditor.id:SetText(data[2] or "");
 	end
 
 	function SoundIDSelfEditor.save(scriptData)
 		scriptData.args[1] = SoundIDSelfEditor.channel:GetSelectedValue() or "SFX";
-		scriptData.args[2] = tonumber(strtrim(SoundIDSelfEditor.id:GetText())) or 0;
+		scriptData.args[2] = tonumber(strtrim(SoundIDSelfEditor.id:GetText()));
 	end
 end
 
@@ -712,7 +715,10 @@ local function sound_id_stop_init()
 
 	SoundIDStopEditor.play:SetText(loc.EFFECT_SOUND_PLAY);
 	SoundIDStopEditor.play:SetScript("OnClick", function(self)
-		Utils.music.playSoundID(tonumber(strtrim(SoundIDStopEditor.id:GetText())), SoundIDStopEditor.channel:GetSelectedValue() or "SFX");
+		local soundID = tonumber(strtrim(SoundIDStopEditor.id:GetText()));
+		if soundID then
+			Utils.music.playSoundID(soundID, SoundIDStopEditor.channel:GetSelectedValue() or "SFX");
+		end
 	end);
 
 	function SoundIDStopEditor.load(scriptData)
@@ -761,7 +767,7 @@ local function sound_music_self_init()
 
 	function soundMusicEditor.load(scriptData)
 		local data = scriptData.args or Globals.empty;
-		soundMusicEditor.path:SetText(data[1]);
+		soundMusicEditor.path:SetText(data[1] or "");
 	end
 
 	function soundMusicEditor.save(scriptData)
@@ -807,7 +813,10 @@ local function sound_id_local_init()
 	setTooltipForSameFrame(soundLocalEditor.id.help, "RIGHT", 0, 5, loc.EFFECT_SOUND_ID_SELF_ID, loc.EFFECT_SOUND_ID_SELF_ID_TT);
 	soundLocalEditor.play:SetText(loc.EFFECT_SOUND_PLAY);
 	soundLocalEditor.play:SetScript("OnClick", function(self)
-		Utils.music.playSoundID(tonumber(strtrim(soundLocalEditor.id:GetText())), soundLocalEditor.channel:GetSelectedValue() or "SFX");
+		local soundID = tonumber(strtrim(soundLocalEditor.id:GetText()));
+		if soundID then
+			Utils.music.playSoundID(soundID, soundLocalEditor.channel:GetSelectedValue() or "SFX");
+		end
 	end);
 
 	-- Distance
@@ -817,8 +826,8 @@ local function sound_id_local_init()
 	function soundLocalEditor.load(scriptData)
 		local data = scriptData.args or Globals.empty;
 		soundLocalEditor.channel:SetSelectedValue(data[1] or "SFX");
-		soundLocalEditor.id:SetText(data[2]);
-		soundLocalEditor.distance:SetText(data[3]);
+		soundLocalEditor.id:SetText(data[2] or "");
+		soundLocalEditor.distance:SetText(data[3] or "");
 	end
 
 	function soundLocalEditor.save(scriptData)
@@ -861,7 +870,10 @@ local function sound_id_local_stop_init()
 
 	SoundIDLocalStopEditor.play:SetText(loc.EFFECT_SOUND_PLAY);
 	SoundIDLocalStopEditor.play:SetScript("OnClick", function(self)
-		Utils.music.playSoundID(tonumber(strtrim(SoundIDLocalStopEditor.id:GetText())), SoundIDLocalStopEditor.channel:GetSelectedValue() or "SFX");
+		local soundID = tonumber(strtrim(SoundIDLocalStopEditor.id:GetText()));
+		if soundID then
+			Utils.music.playSoundID(soundID, SoundIDLocalStopEditor.channel:GetSelectedValue() or "SFX");
+		end
 	end);
 
 	function SoundIDLocalStopEditor.load(scriptData)
@@ -918,8 +930,8 @@ local function sound_music_local_init()
 
 	function musicLocalEditor.load(scriptData)
 		local data = scriptData.args or Globals.empty;
-		musicLocalEditor.path:SetText(data[1]);
-		musicLocalEditor.distance:SetText(data[2]);
+		musicLocalEditor.path:SetText(data[1] or "");
+		musicLocalEditor.distance:SetText(data[2] or "");
 	end
 
 	function musicLocalEditor.save(scriptData)


### PR DESCRIPTION
- The "Simple rifle" database item had a condition reworked some time ago so it wasn't working, fixed it.

- EJ_GetCurrentInstance has been removed, replaced by C_Map.GetBestMapForUnit. ~~I haven't been able to find the justification for having the first function in the first place, and the new one would cause trouble for people on the border of a map change. For this reason, I just removed it until further notice.~~ It seems it might have been useful when sounds could be played in instances, with multiple floors/maps, not the case anymore.

- There were some missing nil checks in the sound effects.