### PR TITLE
Wrong locale key for trade button setting

### DIFF
--- a/totalRP3_Extended/inventory/inventory_exchange.lua
+++ b/totalRP3_Extended/inventory/inventory_exchange.lua
@@ -630,7 +630,7 @@ TRP3_API.events.listenToEvent(TRP3_API.events.WORKFLOW_ON_LOADED, function()
 		TRP3_API.target.registerButton({
 			id = "aa_player_e_trade",
 			onlyForType = TRP3_API.ui.misc.TYPE_CHARACTER,
-			configText = loc.INV_PAGE_CHARACTER_INSPECTION,
+			configText = loc.IT_EX_TRADE_BUTTON,
 			condition = function(_, unitID)
 				if UnitIsPlayer("target") and unitID ~= Globals.player_id and not UnitIsIgnored(unitID) then
 					if UnitIsKnown("target") then


### PR DESCRIPTION
I only realized while looking at the settings : when I copied the old code for the trade button, I didn't realize the locale key for the config setting was wrong. Fixing it so it doesn't look like the same key is there twice.