### PR TITLE
Inventory effects/conditions small fixes

### DIFF
--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -776,13 +776,9 @@ The function is in the form of:
 	EFFECT_ITEM_COOLDOWN_PREVIEW = "Duration: %s second(s)",
 	EFFECT_COOLDOWN_DURATION_TT = "The cooldown duration, in seconds.",
 	EFFECT_ITEM_SOURCE_ID = "You can select an item ID you want to search, or leave empty if you want to search for all types of items.",
-	EFFECT_ITEM_SOURCE = "Search in",
 	EFFECT_ITEM_SOURCE_1 = "All inventory",
 	EFFECT_ITEM_SOURCE_2 = "Parent container",
 	EFFECT_ITEM_SOURCE_3 = "This item",
-	EFFECT_ITEM_SOURCE_1_TT = "Search for the item(s) inside the entire character inventory.",
-	EFFECT_ITEM_SOURCE_2_TT = "Search for the item(s) only inside this item parent container (and any sub-container).\n\n|cffff9900Only works if this script is in an item context.",
-	EFFECT_ITEM_SOURCE_3_TT = "Search for the item(s) only inside this item (and any sub-container).\n\n|cffff9900Only works if this script is in an item context and this item is a container.",
 	EFFECT_ITEM_USE = "Container: item use",
 	EFFECT_ITEM_USE_TT = "Use a item in a slot in the container.\n\n|cffff9900Only works if this workflow is triggered by a container.",
 	EFFECT_ITEM_USE_PREVIEW = "Use item in slot %s",
@@ -1594,6 +1590,14 @@ http://wowwiki.wikia.com/wiki/Event_API
 	EFFECT_RANDSUM_PREVIEW_FULL = "Summon a random battle pet from your |c0000ff00entire pool|r.",
 	EFFECT_RANDSUM_PREVIEW_FAV = "Summon a random battle pet from your |c0000ff00favourite pool|r.",
 	EFFECT_SUMMOUNT_RANDOMMOUNT = "Random favourite",
+	EFFECT_ITEM_SOURCE_SEARCH = "Search in",
+	EFFECT_ITEM_SOURCE_1_SEARCH_TT = "Search for the item(s) inside the entire character inventory.",
+	EFFECT_ITEM_SOURCE_2_SEARCH_TT = "Search for the item(s) only inside this item parent container (and any sub-container).\n\n|cffff9900Only works if this script is in an item context.",
+	EFFECT_ITEM_SOURCE_3_SEARCH_TT = "Search for the item(s) only inside this item (and any sub-container).\n\n|cffff9900Only works if this script is in an item context and this item is a container.",
+	EFFECT_ITEM_SOURCE_ADD = "Add to",
+	EFFECT_ITEM_SOURCE_1_ADD_TT = "Add the item(s) anywhere inside the entire character inventory, starting with the main container.",
+	EFFECT_ITEM_SOURCE_2_ADD_TT = "Add the item(s) only inside this item parent container (and any sub-container).\n\n|cffff9900Only works if this script is in an item context.",
+	EFFECT_ITEM_SOURCE_3_ADD_TT = "Add the item(s) only inside this item (and any sub-container).\n\n|cffff9900Only works if this script is in an item context and this item is a container.",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended_Tools/items/effects.lua
+++ b/totalRP3_Extended_Tools/items/effects.lua
@@ -187,6 +187,12 @@ local function item_add_init()
 	editor.crafted.Text:SetText(loc.EFFECT_ITEM_ADD_CRAFTED);
 	setTooltipForSameFrame(editor.crafted, "RIGHT", 0, 5, loc.EFFECT_ITEM_ADD_CRAFTED, loc.EFFECT_ITEM_ADD_CRAFTED_TT);
 
+	inventorySources = {
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_ADD, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_ADD_1_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_ADD, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_ADD_2_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_ADD, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_ADD_3_TT},
+	}
+
 	-- Source
 	TRP3_API.ui.listbox.setupListBox(editor.source, inventorySources, nil, nil, 250, true);
 
@@ -241,6 +247,12 @@ local function item_remove_init()
 	-- Count
 	editor.count.title:SetText(loc.EFFECT_ITEM_ADD_QT);
 	setTooltipForSameFrame(editor.count.help, "RIGHT", 0, 5, loc.EFFECT_ITEM_ADD_QT, loc.EFFECT_ITEM_REMOVE_QT_TT);
+
+	inventorySources = {
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_SEARCH_1_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_SEARCH_2_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_SEARCH_3_TT},
+	}
 
 	-- Source
 	TRP3_API.ui.listbox.setupListBox(editor.source, inventorySources, nil, nil, 250, true);
@@ -610,6 +622,12 @@ local function inv_item_count_init()
 		end,
 	});
 
+	inventorySources = {
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_SEARCH_1_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_SEARCH_2_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_SEARCH_3_TT},
+	}
+
 	-- Source
 	TRP3_API.ui.listbox.setupListBox(editor.source, inventorySources, nil, nil, 185, true);
 
@@ -642,6 +660,12 @@ local function inv_item_weight_init()
 		end,
 	});
 
+	inventorySources = {
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_SEARCH_1_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_SEARCH_2_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_SEARCH_3_TT},
+	}
+
 	-- Source
 	TRP3_API.ui.listbox.setupListBox(editor.source, inventorySources, nil, nil, 185, true);
 
@@ -657,11 +681,6 @@ end
 
 function TRP3_API.extended.tools.initItemEffects()
 
-	inventorySources = {
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_1_TT},
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_2_TT},
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_3_TT},
-	}
 	inventorySourcesLocals = {
 		inventory = loc.EFFECT_ITEM_SOURCE_1,
 		parent = loc.EFFECT_ITEM_SOURCE_2,

--- a/totalRP3_Extended_Tools/items/effects.lua
+++ b/totalRP3_Extended_Tools/items/effects.lua
@@ -188,9 +188,9 @@ local function item_add_init()
 	setTooltipForSameFrame(editor.crafted, "RIGHT", 0, 5, loc.EFFECT_ITEM_ADD_CRAFTED, loc.EFFECT_ITEM_ADD_CRAFTED_TT);
 
 	inventorySources = {
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_ADD, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_ADD_1_TT},
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_ADD, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_ADD_2_TT},
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_ADD, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_ADD_3_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_ADD, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_1_ADD_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_ADD, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_2_ADD_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_ADD, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_3_ADD_TT},
 	}
 
 	-- Source
@@ -249,9 +249,9 @@ local function item_remove_init()
 	setTooltipForSameFrame(editor.count.help, "RIGHT", 0, 5, loc.EFFECT_ITEM_ADD_QT, loc.EFFECT_ITEM_REMOVE_QT_TT);
 
 	inventorySources = {
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_SEARCH_1_TT},
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_SEARCH_2_TT},
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_SEARCH_3_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_1_SEARCH_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_2_SEARCH_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_3_SEARCH_TT},
 	}
 
 	-- Source
@@ -623,9 +623,9 @@ local function inv_item_count_init()
 	});
 
 	inventorySources = {
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_SEARCH_1_TT},
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_SEARCH_2_TT},
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_SEARCH_3_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_1_SEARCH_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_2_SEARCH_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_3_SEARCH_TT},
 	}
 
 	-- Source
@@ -661,9 +661,9 @@ local function inv_item_weight_init()
 	});
 
 	inventorySources = {
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_SEARCH_1_TT},
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_SEARCH_2_TT},
-		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_SEARCH_3_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_1), "inventory", loc.EFFECT_ITEM_SOURCE_1_SEARCH_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_2), "parent", loc.EFFECT_ITEM_SOURCE_2_SEARCH_TT},
+		{TRP3_API.formats.dropDownElements:format(loc.EFFECT_ITEM_SOURCE_SEARCH, loc.EFFECT_ITEM_SOURCE_3), "self", loc.EFFECT_ITEM_SOURCE_3_SEARCH_TT},
 	}
 
 	-- Source

--- a/totalRP3_Extended_Tools/items/items.xml
+++ b/totalRP3_Extended_Tools/items/items.xml
@@ -265,7 +265,7 @@
 			<Frame parentKey="source" inherits="UIDropDownMenuTemplate" enableMouse="true" name="$parentSource">
 				<Anchors>
 					<Anchor point="TOP" x="0" y="-40"/>
-					<Anchor point="LEFT" x="15" y="0"/>
+					<Anchor point="LEFT" x="-5" y="0"/>
 					<Anchor point="RIGHT" x="-15" y="0"/>
 				</Anchors>
 			</Frame>


### PR DESCRIPTION
- All effects and conditions used "Search in: *Source*" in the dropdown, which didn't make sense for the "Add item" effect. "Add item" now says "Add to: *Source*". Locale keys were updated to reflect that there can now be multiple wordings for selecting the inventory source.

- As to what was discussed about disabling the invalid dropdown choices : as far as I'm understanding, the editor doesn't easily know the creation where it's called from, so it doesn't seem easy to implement. Likewise, an alert message when using an invalid source doesn't seem easily possible for conditions, and my tests trying to add one to the effects weren't successful either.
Given that the scope of those sources is clearly explained in the tooltip shown when hovering those options, and the updated locale for "Add item", I'm not sure it is worth the effort.

- Bonus change : the container weight condition editor dropdown was misplaced and going out of the box, I fixed its position to stay inside the box.