### PR TITLE
Adding dependency to fix Blizz missing dependency

### DIFF
--- a/totalRP3_Extended/totalRP3_Extended.toc
+++ b/totalRP3_Extended/totalRP3_Extended.toc
@@ -5,6 +5,7 @@
 ## Version: @project-version@
 ## URL: http://extended.totalrp3.info
 ## RequiredDeps: totalRP3
+## OptionalDeps: Blizzard_QuestChoice
 ## DefaultState: Enabled
 ## LoadOnDemand: 0
 ## SavedVariables: TRP3_Tools_DB, TRP3_Exchange_DB, TRP3_Security, TRP3_Drop, TRP3_Stashes


### PR DESCRIPTION
As said in #126, we currently get a `Couldn't find inherited node: QuestChoiceLeftHide, QuestChoiceRightHide, QuestChoiceBottomHide` Lua error on load. Since there hasn't been a fix since, and finding the missing dependency would probably be tricky, an optional dependency has been added to compensate.

The need for this dependency should probably be reevaluated in future updates. Maybe if we have enough time to waste, we can track which part of the code triggers the error to report it to Blizzard.