### PR TITLE
Fixes for some broadcast issues

### DIFF
--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -776,7 +776,7 @@ end
 
 local function startStashesRequest()
 	local posY, posX = UnitPosition("player");
-	local mapID = WorldMapFrame:GetMapID();
+	local mapID = C_Map.GetBestMapForUnit("player");
 	if posX and posY then
 		stashFoundFrame:Hide();
 		stashEditFrame:Hide();

--- a/totalRP3_Extended/misc/sounds.lua
+++ b/totalRP3_Extended/misc/sounds.lua
@@ -33,7 +33,6 @@ local LOCAL_STOPSOUND_COMMAND = "STS";
 
 local function getPosition()
 	local posY, posX, posZ, instanceID = UnitPosition("player");
-	instanceID = instanceID;
 	posY = floor(posY + 0.5);
 	posX = floor(posX + 0.5);
 	return posY, posX, posZ, instanceID;
@@ -78,6 +77,7 @@ local function initSharedSound()
 				posY = tonumber(posY) or 0;
 				posX = tonumber(posX) or 0;
 				posZ = tonumber(posZ) or 0;
+				instanceID = tonumber(instanceID) or -1;
 
 				if sender == Globals.player_id then
 					if channel ~= "Music" then
@@ -88,7 +88,6 @@ local function initSharedSound()
 				else
 					-- Get current position
 					local myPosY, myPosX, myPosZ, myInstanceID = UnitPosition("player");
-					myInstanceID = myInstanceID;
 					myPosY = floor(myPosY + 0.5);
 					myPosX = floor(myPosX + 0.5);
 


### PR DESCRIPTION
- Searching for other players' stashes wasn't working because I used the wrong function to replace GetCurrentMapID when starting the request.

- Broadcasting a local sound/music wasn't working because the removal of the string concatenation with EJ_GetCurrentInstance caused instanceID and myInstanceID to be different types (instanceID, coming from a broadcast command, was a string).

Also maybe I should get my eyes checked because I didn't realize when removing the concatenation that it created useless lines...