### PR TITLE
Drops fix

### DIFF
--- a/totalRP3_Extended/flyway/flyway.lua
+++ b/totalRP3_Extended/flyway/flyway.lua
@@ -22,7 +22,7 @@ TRP3_API.extended.flyway = {};
 
 local type, tostring = type, tostring;
 
-local SCHEMA_VERSION = 1;
+local SCHEMA_VERSION = 2;
 
 if not TRP3_Extended_Flyway then
     TRP3_Extended_Flyway = {};

--- a/totalRP3_Extended/flyway/flyway_patches.lua
+++ b/totalRP3_Extended/flyway/flyway_patches.lua
@@ -367,3 +367,17 @@ TRP3_API.extended.flyway.patches["1"] = function()
         end
     end
 end
+
+-- Fixing wrong array key for drops in 1.2.0
+TRP3_API.extended.flyway.patches["2"] = function()
+    if TRP3_Drop then
+        for realmID, realmTab in pairs(TRP3_Drop) do
+            for dropID, drop in pairs(realmTab) do
+                if drop.mapID then
+                    drop.uiMapID = drop.mapID;
+                    drop.mapID = nil;
+                end
+            end
+        end
+    end
+end

--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -48,7 +48,7 @@ local function dropCommon(lootInfo)
 		posY = posY,
 		posX = posX,
 		posZ = posZ,
-		mapID = mapID,
+		uiMapID = mapID,
 		mapX = mapX,
 		mapY = mapY,
 		item = {}


### PR DESCRIPTION
When I made the change from mapID to uiMapID, I fixed the array key name for the previous stashes/drops and the newly created stashes, but unfortunately kept the wrong key for drops, meaning newly created drops couldn't be found again.

I'll go hide in a corner while the flyway patch luckily fixes the issue.