### PR TITLE
Issue #153 : Make sure conditions arguments cannot be nil

### DIFF
--- a/totalRP3_Extended/script/script_generation.lua
+++ b/totalRP3_Extended/script/script_generation.lua
@@ -106,7 +106,7 @@ local function operand(operandID, eArgs, ...)
 	local cArgs = {...};
 	local operandInfo = getTestOperande(operandID);
 	if operandInfo then
-		local code = "return function(args)\nreturn " .. operandInfo.codeReplacement(escapeArguments(cArgs)) .. "\nend;";
+		local code = "return function(args)\nreturn " .. operandInfo.codeReplacement(escapeArguments(cArgs) or EMPTY) .. "\nend;";
 		-- Compile
 		-- TODO: with proper method
 		local factory, errorMessage = loadstring(code, "Generated direct operand code");
@@ -193,9 +193,9 @@ local function writeOperand(testStructure, comparatorType, env)
 		assert(comparatorType ~= "number" or operandInfo.numeric, "Operand ID is not numeric: " .. testStructure.i);
 
 		if comparatorType == "number" then
-			code = ("(tonumber(%s) or -1)"):format(operandInfo.codeReplacement(escapeArguments(testStructure.a)));
+			code = ("(tonumber(%s) or -1)"):format(operandInfo.codeReplacement(escapeArguments(testStructure.a) or EMPTY));
 		else
-			code = ("tostring(%s)"):format(operandInfo.codeReplacement(escapeArguments(testStructure.a)));
+			code = ("tostring(%s)"):format(operandInfo.codeReplacement(escapeArguments(testStructure.a) or EMPTY));
 		end
 
 

--- a/totalRP3_Extended_Tools/script/conditions/conditions.lua
+++ b/totalRP3_Extended_Tools/script/conditions/conditions.lua
@@ -168,10 +168,6 @@ local function onOperandSelected(operandID, list, loadEditor)
 
 	setTooltipForSameFrame(list, "TOP", 0, 0);
 
-	if not list.argsData then
-		list.argsData = EMPTY;
-	end
-
 	local hasPreview = false;
 	local operandInfo = getOperandEditorInfo(operandID);
 	if operandInfo ~= EMPTY then
@@ -627,7 +623,7 @@ function editor.init()
 	TRP3_API.ui.listbox.setupListBox(operandEditor.comparator, comparatorStructure, checkNumeric, nil, 175, true);
 
 	TRP3_API.ui.listbox.setupListBox(operandEditor.left, getEvaluatedOperands(leftListStructure), function(operandID, list)
-		list.argsData = nil;
+		list.argsData = EMPTY;
 		onOperandSelected(operandID, list, true);
 	end, nil, 220, true);
 	TRP3_API.ui.frame.configureHoverFrame(operandEditor.left.args, operandEditor.left, "TOP", 0, 5, true, operandEditor.left);
@@ -653,7 +649,7 @@ function editor.init()
 		}},
 	}
 	TRP3_API.ui.listbox.setupListBox(operandEditor.right, rightStructure, function(operandID, list)
-		list.argsData = nil;
+		list.argsData = EMPTY;
 		onOperandSelected(operandID, list, true);
 	end, nil, 220, true);
 	TRP3_API.ui.frame.configureHoverFrame(operandEditor.right.args, operandEditor.right, "TOP", 0, 5, true, operandEditor.right);

--- a/totalRP3_Extended_Tools/script/conditions/conditions.lua
+++ b/totalRP3_Extended_Tools/script/conditions/conditions.lua
@@ -224,7 +224,7 @@ local function onPreviewClick(button)
 	local list = button:GetParent();
 	local operandInfo = TRP3_API.script.getOperand(list.operandID);
 	if operandInfo and operandInfo.codeReplacement then
-		local code = ("displayMessage(\"|cffff9900" .. loc.OP_PREVIEW .. ":|cffffffff \" .. tostring(%s));"):format(operandInfo.codeReplacement(list.argsData));
+		local code = ("displayMessage(\"|cffff9900" .. loc.OP_PREVIEW .. ":|cffffffff \" .. tostring(%s));"):format(operandInfo.codeReplacement(list.argsData or EMPTY));
 		local env = {};
 		Utils.table.copy(env, previewEnv);
 		Utils.table.copy(env, operandInfo.env);

--- a/totalRP3_Extended_Tools/script/conditions/conditions.lua
+++ b/totalRP3_Extended_Tools/script/conditions/conditions.lua
@@ -168,6 +168,10 @@ local function onOperandSelected(operandID, list, loadEditor)
 
 	setTooltipForSameFrame(list, "TOP", 0, 0);
 
+	if not list.argsData then
+		list.argsData = EMPTY;
+	end
+
 	local hasPreview = false;
 	local operandInfo = getOperandEditorInfo(operandID);
 	if operandInfo ~= EMPTY then
@@ -180,7 +184,7 @@ local function onOperandSelected(operandID, list, loadEditor)
 		end
 		if not operandInfo.noPreview then
 			list.preview:Enable();
-			hasPreview = false;
+			hasPreview = true;
 		end
 		local returnType = type(operandInfo.returnType);
 		local returnTypeText;


### PR DESCRIPTION
When you select a condition which needs arguments, a popup appears to confirm those arguments. If you confirm the condition without confirming the condition arguments, the arguments array will stay nil. While operands code generation is accounting for an empty arguments array with default values, it doesn't handle a nil array.

Rather than add a `or EMPTY` to every single `args` in the operands code generation (as is done in the editor, which is why the issue wasn't obvious to the user), I'm now setting the argsData to `EMPTY` instead of `nil` upon operand selection, and making sure on script generation that the arguments array isn't nil for good measure.

As a useless bonus, I fixed the boolean `hasPreview` returned on operand selection if preview is available. It's not actually used anywhere, the button behaviour must be set elsewhere, so I could just remove it if you want :p