### PR TITLE
Feature/secured macros

### DIFF
--- a/totalRP3_Extended/SecureEnclave.lua
+++ b/totalRP3_Extended/SecureEnclave.lua
@@ -33,7 +33,9 @@ end
 
 ---@param macroCommands string
 function SecureEnclave:AddSecureCommands(macroCommands)
-	enclave[#enclave + 1] = macroCommands;
+	if shouldEnclaveCollectCommands then
+		enclave[#enclave + 1] = macroCommands;
+	end
 end
 
 ---@return string

--- a/totalRP3_Extended/SecureEnclave.lua
+++ b/totalRP3_Extended/SecureEnclave.lua
@@ -1,0 +1,54 @@
+----------------------------------------------------------------------------------
+--- Total RP 3
+---	------------------------------------------------------------------------------
+--- Copyright 2018 Renaud "Ellypse" Parize <ellypse@totalrp3.info> @EllypseCelwe
+---
+--- Licensed under the Apache License, Version 2.0 (the "License");
+--- you may not use this file except in compliance with the License.
+--- You may obtain a copy of the License at
+---
+---  http://www.apache.org/licenses/LICENSE-2.0
+---
+--- Unless required by applicable law or agreed to in writing, software
+--- distributed under the License is distributed on an "AS IS" BASIS,
+--- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--- See the License for the specific language governing permissions and
+--- limitations under the License.
+----------------------------------------------------------------------------------
+
+local _, Private_TRP3E = ...;
+
+--- This module is responsible for securely collecting macro commands to run for the user.
+--- This should be as secure as humanly possible, avoid calling global functions.
+---@class SecureEnclave
+local SecureEnclave = {};
+
+local enclave = {};
+local shouldEnclaveCollectCommands = false;
+
+function SecureEnclave:StartCollectingSecureCommands()
+	shouldEnclaveCollectCommands = true;
+	enclave = {};
+end
+
+---@param macroCommands string
+function SecureEnclave:AddSecureCommands(macroCommands)
+	enclave[#enclave + 1] = macroCommands;
+end
+
+---@return string
+function SecureEnclave:GetSecureCommands()
+
+	-- Create a copy of the table instead of passing a direct reference, for security reasons
+	local enclaveContent = "";
+	for i = 1, #enclave do
+		enclaveContent = enclaveContent .. enclave[i] .. "\n";
+	end
+
+	shouldEnclaveCollectCommands = false;
+	enclave = {};
+
+	return enclaveContent;
+end
+
+Private_TRP3E.SecureEnclave = SecureEnclave

--- a/totalRP3_Extended/inventory/container.lua
+++ b/totalRP3_Extended/inventory/container.lua
@@ -18,8 +18,8 @@
 
 local _, Private_TRP3E = ...;
 
----@type SecureEnclave
-local SecureEnclave = Private_TRP3E.SecureEnclave
+---@type SecuredMacroCommandsEnclave
+local SecuredMacroCommandsEnclave = Private_TRP3E.SecuredMacroCommandsEnclave
 
 local Ellyb = TRP3_API.Ellyb;
 
@@ -536,9 +536,9 @@ local function initContainerSlot(slot, simpleLeftClick, lootBuilder)
 		slot:SetAttribute("type", "macro");
 		-- OnMouseDown is called before the OnClick script, which gives us the opportunity to setup the macro behavior before use
 		slot:SetScript("OnMouseDown", function(self, button)
-			SecureEnclave:StartCollectingSecureCommands();
+			SecuredMacroCommandsEnclave:StartCollectingSecureCommands();
 			slot.trp3func(self, button);
-			slot:SetAttribute("macrotext", SecureEnclave:GetSecureCommands());
+			slot:SetAttribute("macrotext", SecuredMacroCommandsEnclave:GetSecureCommands());
 		end)
 
 		-- This function is manually called from the macro environment

--- a/totalRP3_Extended/inventory/container.lua
+++ b/totalRP3_Extended/inventory/container.lua
@@ -2,6 +2,7 @@
 -- Total RP 3
 --	---------------------------------------------------------------------------
 --	Copyright 2015 Sylvain Cossement (telkostrasz@totalrp3.info)
+--	Copyright 2018 Renaud "Ellypse" Parize <ellypse@totalrp3.info> @EllypseCelwe
 --
 --	Licensed under the Apache License, Version 2.0 (the "License");
 --	you may not use this file except in compliance with the License.

--- a/totalRP3_Extended/inventory/inventory.xml
+++ b/totalRP3_Extended/inventory/inventory.xml
@@ -1,10 +1,11 @@
-﻿<Ui xmlns="http://www.blizzard.com/wow/ui/" 
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+﻿<Ui xmlns="http://www.blizzard.com/wow/ui/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.blizzard.com/wow/ui/">
-	
+
 <!--
 	Total RP 3
 	Copyright 2015 Sylvain Cossement (telkostrasz@totalrp3.info)
+	Copyright 2018 Renaud "Ellypse" Parize <ellypse@totalrp3.info> @EllypseCelwe
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.

--- a/totalRP3_Extended/inventory/inventory.xml
+++ b/totalRP3_Extended/inventory/inventory.xml
@@ -104,7 +104,7 @@
 	<!--      Containers      -->
 	<!-- *_*_*_*_*_*_*_*_*_*  -->
 
-	<Button name="TRP3_ContainerSlotTemplate" enableMouse="true" virtual="true">
+	<Button name="TRP3_ContainerSlotTemplate" inherits="InsecureActionButtonTemplate" enableMouse="true" virtual="true">
 		<Size x="36" y="36"/>
 		<Layers>
 			<Layer level="BORDER">
@@ -147,9 +147,9 @@
 		<HighlightTexture alphaMode="ADD" file="Interface\Buttons\ButtonHilight-Square"/>
 	</Button>
 
-	<Frame name="TRP3_ItemDragButton" inherits="TRP3_ContainerSlotTemplate" parent="UIParent" frameStrata="DIALOG" hidden="true" movable="true" enableMouse="false">
+	<Button name="TRP3_ItemDragButton" inherits="TRP3_ContainerSlotTemplate" parent="UIParent" frameStrata="DIALOG" hidden="true" movable="true" enableMouse="false">
 
-	</Frame>
+	</Button>
 
 	<Frame name="TRP3_Container5x4Template" frameStrata="PARENT" toplevel="true" enableMouse="true" virtual="true" hidden="true" clampedToScreen="true" movable="true">
 		<Size x="200" y="270" />

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1611,7 +1611,7 @@ http://wowwiki.wikia.com/wiki/Event_API
 
 |cffccccccNotes:
 - This effect will only be run if the workflow is called following a user action (use an item, click on a dialog choice in a cutscene).
-- This effect is not impacted by delays inside the workflow. Because macros can execute secure actions, all macro effects will be executed immediately after the user action.
+- This effect is not impacted by delays inside the workflow. Because macros can execute secure actions, all macro effects have to be executed immediately after the user action.
 - This effect IS affected by conditions and can resolve variables.
 - This effect will NEVER be run while in combat or when called by an event in a campaign.
 |r]],
@@ -1620,6 +1620,7 @@ http://wowwiki.wikia.com/wiki/Event_API
 
 You can also use Total RP 3: Extended variables (|cffcccccc${my_var_name}|r).
 ]],
+	SEC_DANGEROUS_TT = "This item, or one of its related objects, uses one or more effects capable of running unrestricted Lua code. Only accept these effects if you trust its author.",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1623,7 +1623,7 @@ You can also use Total RP 3: Extended variables (|cffcccccc${my_var_name}|r).
 	SEC_REASON_MACRO = [[Execute a macro]],
 	SEC_REASON_MACRO_WHY = [[This object could trigger any macro commands.
 
-|cffff0000It may cast spells or consume items (outside of combat). It may also execute any Lua code available to add-ons and affect your inventory, gold, guild, be used in a malicious way to force you so say something reprehensible by the Blizzard terms of services that can make you banned from the game.
+|cffff0000It may cast spells or consume items (outside of combat). It may also execute any Lua code available to add-ons and affect your inventory, gold, guild, be used in a malicious way to force you so to say something reprehensible by the Blizzard terms of services that can make you banned from the game.
 
 |cff00ff00If blocked, the macro commands will not be executed but printed in the chat frame instead.]],
 

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1620,6 +1620,7 @@ http://wowwiki.wikia.com/wiki/Event_API
 
 You can also use Total RP 3: Extended variables (|cffcccccc${my_var_name}|r).
 ]],
+	SEC_REASON_MACRO = [[Execute a macro]],
 	SEC_REASON_MACRO_WHY = [[This object could trigger any macro commands.
 
 |cffff0000It may cast spells or consume items (outside of combat). It may also execute any Lua code available to add-ons and affect your inventory, gold, guild, be used in a malicious way to force you so say something reprehensible by the Blizzard terms of services that can make you banned from the game.
@@ -1630,6 +1631,7 @@ You can also use Total RP 3: Extended variables (|cffcccccc${my_var_name}|r).
 	SEC_RESOLUTION_ALL = "For all objects",
 	SEC_RESOLUTION_THIS_OBJECT = "For this object only",
 	SEC_RESOLUTION_AUTHOR = "You are the author",
+	EFFECT_SECURE_MACRO_BLOCKED = "Blocked macro effect:",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1620,7 +1620,16 @@ http://wowwiki.wikia.com/wiki/Event_API
 
 You can also use Total RP 3: Extended variables (|cffcccccc${my_var_name}|r).
 ]],
-	SEC_DANGEROUS_TT = "This item, or one of its related objects, uses one or more effects capable of running unrestricted Lua code. Only accept these effects if you trust its author.",
+	SEC_REASON_MACRO_WHY = [[This object could trigger any macro commands.
+
+|cffff0000It may cast spells or consume items (outside of combat). It may also execute any Lua code available to add-ons and affect your inventory, gold, guild, be used in a malicious way to force you so say something reprehensible by the Blizzard terms of services that can make you banned from the game.
+
+|cff00ff00If blocked, the macro commands will not be executed but printed in the chat frame instead.]],
+
+	SEC_RESOLUTION_WHITELISTED = "Whitelisted sender",
+	SEC_RESOLUTION_ALL = "For all objects",
+	SEC_RESOLUTION_THIS_OBJECT = "For this object only",
+	SEC_RESOLUTION_AUTHOR = "You are the author",
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended/locale.lua
+++ b/totalRP3_Extended/locale.lua
@@ -1606,6 +1606,20 @@ http://wowwiki.wikia.com/wiki/Event_API
 	------------------------------------------------------------------------------------------------
 
 	DR_STASHES_OWNER = "Owner",
+	EFFECT_SECURE_MACRO_ACTION_NAME = "Execute macro",
+	EFFECT_SECURE_MACRO_DESCRIPTION = [[Execute custom macro commands.
+
+|cffccccccNotes:
+- This effect will only be run if the workflow is called following a user action (use an item, click on a dialog choice in a cutscene).
+- This effect is not impacted by delays inside the workflow. Because macros can execute secure actions, all macro effects will be executed immediately after the user action.
+- This effect IS affected by conditions and can resolve variables.
+- This effect will NEVER be run while in combat or when called by an event in a campaign.
+|r]],
+	EFFECT_SECURE_MACRO_HELP_TITLE = "Macro commands",
+	EFFECT_SECURE_MACRO_HELP = [[You can use any commands you would normally use in a macro, including other add-ons' custom /slash commands.
+
+You can also use Total RP 3: Extended variables (|cffcccccc${my_var_name}|r).
+]],
 }
 
 Localization:GetDefaultLocale():AddTexts(TRP3_API.loc);

--- a/totalRP3_Extended/script/SecuredMacroCommandsEnclave.lua
+++ b/totalRP3_Extended/script/SecuredMacroCommandsEnclave.lua
@@ -33,7 +33,7 @@ function SecuredMacroCommandsEnclave:StartCollectingSecureCommands()
 end
 
 --- Add a macro command to the SecuredMacroCommandsEnclave.
---- The command will be ignored if added add a time when the enclave is not collecting.
+--- The command will be ignored if added add at a time when the enclave is not collecting.
 ---@param macroCommands string
 function SecuredMacroCommandsEnclave:AddSecureCommands(macroCommands)
 	if shouldEnclaveCollectCommands then

--- a/totalRP3_Extended/script/SecuredMacroCommandsEnclave.lua
+++ b/totalRP3_Extended/script/SecuredMacroCommandsEnclave.lua
@@ -20,26 +20,30 @@ local _, Private_TRP3E = ...;
 
 --- This module is responsible for securely collecting macro commands to run for the user.
 --- This should be as secure as humanly possible, avoid calling global functions.
----@class SecureEnclave
-local SecureEnclave = {};
+---@class SecuredMacroCommandsEnclave
+local SecuredMacroCommandsEnclave = {};
 
 local enclave = {};
 local shouldEnclaveCollectCommands = false;
 
-function SecureEnclave:StartCollectingSecureCommands()
+--- Ask the SecuredMacroCommandsEnclave to start collecting macro commands
+function SecuredMacroCommandsEnclave:StartCollectingSecureCommands()
 	shouldEnclaveCollectCommands = true;
 	enclave = {};
 end
 
+--- Add a macro command to the SecuredMacroCommandsEnclave.
+--- The command will be ignored if added add a time when the enclave is not collecting.
 ---@param macroCommands string
-function SecureEnclave:AddSecureCommands(macroCommands)
+function SecuredMacroCommandsEnclave:AddSecureCommands(macroCommands)
 	if shouldEnclaveCollectCommands then
 		enclave[#enclave + 1] = macroCommands;
 	end
 end
 
+--- Fetch all macro commands from the SecuredMacroCommandsEnclave
 ---@return string
-function SecureEnclave:GetSecureCommands()
+function SecuredMacroCommandsEnclave:GetSecureCommands()
 
 	-- Create a copy of the table instead of passing a direct reference, for security reasons
 	local enclaveContent = "";
@@ -53,4 +57,4 @@ function SecureEnclave:GetSecureCommands()
 	return enclaveContent;
 end
 
-Private_TRP3E.SecureEnclave = SecureEnclave
+Private_TRP3E.SecuredMacroCommandsEnclave = SecuredMacroCommandsEnclave

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -444,7 +444,7 @@ local EFFECTS = {
 		securedMethod = function(structure, cArgs, eArgs)
 			local macroText = tostring(cArgs[1]);
 			macroText = TRP3_API.script.parseArgs(macroText, eArgs);
-			TRP3_API.utils.message.displayMessage(macroText, 1);
+			TRP3_API.utils.message.displayMessage(loc.EFFECT_SECURE_MACRO_BLOCKED .. " " .. tostring(macroText), 1);
 			eArgs.LAST = 0
 		end,
 		secured = security.LOW,

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -19,6 +19,11 @@
 
 -- Fixed the "Summon Mount" effect (Paul Corlay)
 
+local _, Private_TRP3E = ...;
+
+---@type SecureEnclave
+local SecureEnclave = Private_TRP3E.SecureEnclave;
+
 local assert, type, tostring, error, tonumber, pairs, unpack, wipe = assert, type, tostring, error, tonumber, pairs, unpack, wipe;
 local loc = TRP3_API.loc;
 
@@ -431,10 +436,16 @@ local EFFECTS = {
 	["secure_macro"] = {
 		-- Secure macros have no code in methods, their code is special and needs to be executed in a pre-use hook
 		method = function(structure, cArgs, eArgs)
-			eArgs.LAST = InCombatLockdown() -- Indicates if the macro was executed or not
+			local macroText = tostring(cArgs[1]);
+			macroText = TRP3_API.script.parseArgs(macroText, eArgs);
+			SecureEnclave:AddSecureCommands(macroText)
+			eArgs.LAST =0
 		end,
 		securedMethod = function(structure, cArgs, eArgs)
-			eArgs.LAST = InCombatLockdown()
+			local macroText = tostring(cArgs[1]);
+			macroText = TRP3_API.script.parseArgs(macroText, eArgs);
+			TRP3_API.utils.message.displayMessage(macroText, 1);
+			eArgs.LAST = 0
 		end,
 		secured = security.LOW,
 	},

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -427,6 +427,18 @@ local EFFECTS = {
 		secured = security.LOW,
 	},
 
+	-- SECURED MACRO
+	["secure_macro"] = {
+		-- Secure macros have no code in methods, their code is special and needs to be executed in a pre-use hook
+		method = function(structure, cArgs, eArgs)
+			eArgs.LAST = InCombatLockdown() -- Indicates if the macro was executed or not
+		end,
+		securedMethod = function(structure, cArgs, eArgs)
+			eArgs.LAST = InCombatLockdown()
+		end,
+		secured = security.LOW,
+	},
+
 	-- PROMPT
 	["var_prompt"] = {
 		method = function(structure, cArgs, eArgs)

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -447,7 +447,7 @@ local EFFECTS = {
 			TRP3_API.utils.message.displayMessage(macroText, 1);
 			eArgs.LAST = 0
 		end,
-		secured = security.DANGEROUS,
+		secured = security.LOW,
 	},
 
 	-- PROMPT

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -447,7 +447,7 @@ local EFFECTS = {
 			TRP3_API.utils.message.displayMessage(macroText, 1);
 			eArgs.LAST = 0
 		end,
-		secured = security.LOW,
+		secured = security.DANGEROUS,
 	},
 
 	-- PROMPT

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -21,8 +21,8 @@
 
 local _, Private_TRP3E = ...;
 
----@type SecureEnclave
-local SecureEnclave = Private_TRP3E.SecureEnclave;
+---@type SecuredMacroCommandsEnclave
+local SecuredMacroCommandsEnclave = Private_TRP3E.SecuredMacroCommandsEnclave;
 
 local assert, type, tostring, error, tonumber, pairs, unpack, wipe = assert, type, tostring, error, tonumber, pairs, unpack, wipe;
 local loc = TRP3_API.loc;
@@ -438,7 +438,7 @@ local EFFECTS = {
 		method = function(structure, cArgs, eArgs)
 			local macroText = tostring(cArgs[1]);
 			macroText = TRP3_API.script.parseArgs(macroText, eArgs);
-			SecureEnclave:AddSecureCommands(macroText)
+			SecuredMacroCommandsEnclave:AddSecureCommands(macroText)
 			eArgs.LAST =0
 		end,
 		securedMethod = function(structure, cArgs, eArgs)

--- a/totalRP3_Extended/script/script_effects.lua
+++ b/totalRP3_Extended/script/script_effects.lua
@@ -3,7 +3,7 @@
 -- Scripts : Effects
 --	---------------------------------------------------------------------------
 --	Copyright 2015 Sylvain Cossement (telkostrasz@telkostrasz.be)
---
+--	Copyright 2018 Renaud "Ellypse" Parize <ellypse@totalrp3.info> @EllypseCelwe
 --	Licensed under the Apache License, Version 2.0 (the "License");
 --	you may not use this file except in compliance with the License.
 --	You may obtain a copy of the License at
@@ -434,12 +434,11 @@ local EFFECTS = {
 
 	-- SECURED MACRO
 	["secure_macro"] = {
-		-- Secure macros have no code in methods, their code is special and needs to be executed in a pre-use hook
 		method = function(structure, cArgs, eArgs)
 			local macroText = tostring(cArgs[1]);
 			macroText = TRP3_API.script.parseArgs(macroText, eArgs);
-			SecuredMacroCommandsEnclave:AddSecureCommands(macroText)
-			eArgs.LAST =0
+			SecuredMacroCommandsEnclave:AddSecureCommands(macroText);
+			eArgs.LAST = 0
 		end,
 		securedMethod = function(structure, cArgs, eArgs)
 			local macroText = tostring(cArgs[1]);

--- a/totalRP3_Extended/security.lua
+++ b/totalRP3_Extended/security.lua
@@ -1,8 +1,9 @@
 ----------------------------------------------------------------------------------
 --- Total RP 3
 ---	---------------------------------------------------------------------------
----	Copyright 2016 Sylvain Cossement (telkostrasz@totalrp3.info)
+--- Copyright 2016 Sylvain Cossement (telkostrasz@totalrp3.info)
 --- Copyright 2018 Renaud "Ellypse" Parize <ellypse@totalrp3.info> @EllypseCelwe
+---
 ---	Licensed under the Apache License, Version 2.0 (the "License");
 ---	you may not use this file except in compliance with the License.
 ---	You may obtain a copy of the License at

--- a/totalRP3_Extended/security.lua
+++ b/totalRP3_Extended/security.lua
@@ -106,7 +106,7 @@ local function computeSecurity(rootObjectID, rootObject, details)
 	assert(rootObject.TY, "Object has no type.");
 	assert(rootObject.TY == TRP3_DB.types.ITEM or rootObject.TY == TRP3_DB.types.CAMPAIGN, "Object is not an item or a campaign.");
 
-	local details = details or {};
+	details = details or {};
 
 	local minSecurity = SECURITY_LEVEL.HIGH;
 	iterateObject(rootObjectID, rootObject, function(childID, childClass)
@@ -228,7 +228,7 @@ end
 function showSecurityDetailFrame(classID, frameFrom)
 	local class = getClass(classID);
 
-	securityFrame.securityDetails = class.details or computeSecurity(classID, class);
+	securityFrame.securityDetails = computeSecurity(classID, class);
 
 	local height = NORMAL_HEIGHT;
 

--- a/totalRP3_Extended/security.lua
+++ b/totalRP3_Extended/security.lua
@@ -28,6 +28,7 @@ TRP3_API.security = {};
 local securityVault;
 
 local SECURITY_LEVEL = {
+	DANGEROUS = 0,
 	LOW = 1,
 	MEDIUM = 2,
 	HIGH = 3,
@@ -289,6 +290,7 @@ function TRP3_API.security.initSecurity()
 	securityLevelDetailText[SECURITY_LEVEL.LOW] = loc.SEC_LOW_TT;
 	securityLevelDetailText[SECURITY_LEVEL.MEDIUM] = loc.SEC_MEDIUM_TT;
 	securityLevelDetailText[SECURITY_LEVEL.HIGH] = loc.SEC_HIGH_TT;
+	securityLevelDetailText[SECURITY_LEVEL.DANGEROUS] = loc.SEC_DANGEROUS_TT;
 	securityResolutionText = {
 		"Whitelisted sender", --TODO: locasl
 		"For all objects", --TODO: locasl

--- a/totalRP3_Extended/security.xml
+++ b/totalRP3_Extended/security.xml
@@ -187,5 +187,5 @@
 		</Frames>
 	</Frame>
 
-	<Script file="SecureEnclave.lua" />
+	<Script file="script/SecuredMacroCommandsEnclave.lua" />
 </Ui>

--- a/totalRP3_Extended/security.xml
+++ b/totalRP3_Extended/security.xml
@@ -1,10 +1,11 @@
-﻿<Ui xmlns="http://www.blizzard.com/wow/ui/" 
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+﻿<Ui xmlns="http://www.blizzard.com/wow/ui/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.blizzard.com/wow/ui/">
-	
+
 <!--
 	Total RP 3
 	Copyright 2014 Sylvain Cossement (telkostrasz@totalrp3.info)
+	Copyright 2018 Renaud "Ellypse" Parize <ellypse@totalrp3.info> @EllypseCelwe
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.

--- a/totalRP3_Extended/security.xml
+++ b/totalRP3_Extended/security.xml
@@ -187,4 +187,5 @@
 		</Frames>
 	</Frame>
 
+	<Script file="SecureEnclave.lua" />
 </Ui>

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -98,13 +98,11 @@ local function macro_init()
 	local editor = TRP3_EffectEditorMacro;
 
 	registerEffectEditor("secure_macro",{
-		title = "Run macro",
-		icon = "inv_inscription_scrollofwisdom_01",
-		description = [[Execute a custom macro
-
-|cffff0000Note: This effect will NEVER be run while in combat.]],
+		title = loc.EFFECT_SECURE_MACRO_ACTION_NAME,
+		icon = "inv_eng_gizmo3",
+		description = loc.EFFECT_SECURE_MACRO_DESCRIPTION,
 		effectFrameDecorator = function(scriptStepFrame, args)
-			scriptStepFrame.description:SetText("|cffffff00Execute macro:|r " .. tostring(args[1]));
+			scriptStepFrame.description:SetText(Ellyb.ColorManager.YELLOW(loc.EFFECT_SECURE_MACRO_ACTION_NAME .. ": ") .. tostring(args[1]));
 		end,
 		getDefaultArgs = function()
 			return {""};
@@ -113,7 +111,7 @@ local function macro_init()
 	})
 
 	-- Text
-	setTooltipAll(editor.macroText.dummy, "RIGHT", 0, 5, "Macro code", "You can use any macro command");
+	setTooltipAll(editor.macroText.dummy, "RIGHT", 0, 5, loc.EFFECT_SECURE_MACRO_HELP_TITLE, loc.EFFECT_SECURE_MACRO_HELP);
 
 	function editor.load(scriptData)
 		local data = scriptData.args or Globals.empty;

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -93,6 +93,38 @@ local function text_init()
 	end
 end
 
+local function macro_init()
+
+	local editor = TRP3_EffectEditorMacro;
+
+	registerEffectEditor("secure_macro",{
+		title = "Run macro",
+		icon = "inv_inscription_scrollofwisdom_01",
+		description = [[Execute a custom macro
+
+|cffff0000Note: This effect will NEVER be run while in combat.]],
+		effectFrameDecorator = function(scriptStepFrame, args)
+			scriptStepFrame.description:SetText("|cffffff00Execute macro:|r " .. tostring(args[1]));
+		end,
+		getDefaultArgs = function()
+			return {""};
+		end,
+		editor = editor,
+	})
+
+	-- Text
+	setTooltipAll(editor.macroText.dummy, "RIGHT", 0, 5, "Macro code", "You can use any macro command");
+
+	function editor.load(scriptData)
+		local data = scriptData.args or Globals.empty;
+		editor.macroText.scroll.text:SetText(data[1] or "");
+	end
+
+	function editor.save(scriptData)
+		scriptData.args[1] = stEtN(strtrim(editor.macroText.scroll.text:GetText()));
+	end
+end
+
 local function script_init()
 
 	local editor = TRP3_EffectEditorScript;
@@ -1083,6 +1115,7 @@ end
 
 function TRP3_API.extended.tools.initBaseEffects()
 	text_init();
+	macro_init();
 	script_init();
 
 	companion_dismiss_mount_init();

--- a/totalRP3_Extended_Tools/script/effects/effects.lua
+++ b/totalRP3_Extended_Tools/script/effects/effects.lua
@@ -2,6 +2,7 @@
 -- Total RP 3: Extended features
 --	---------------------------------------------------------------------------
 --	Copyright 2015 Sylvain Cossement (telkostrasz@totalrp3.info)
+--	Copyright 2018 Renaud "Ellypse" Parize <ellypse@totalrp3.info> @EllypseCelwe
 --
 --	Licensed under the Apache License, Version 2.0 (the "License");
 --	you may not use this file except in compliance with the License.

--- a/totalRP3_Extended_Tools/script/effects/effects.xml
+++ b/totalRP3_Extended_Tools/script/effects/effects.xml
@@ -1,10 +1,11 @@
-﻿<Ui xmlns="http://www.blizzard.com/wow/ui/" 
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+﻿<Ui xmlns="http://www.blizzard.com/wow/ui/"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.blizzard.com/wow/ui/">
-	
+
 <!--
 	Total RP 3
 	Copyright 2014-2016 Sylvain Cossement (telkostrasz@totalrp3.info)
+	Copyright 2018 Renaud "Ellypse" Parize <ellypse@totalrp3.info> @EllypseCelwe
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.

--- a/totalRP3_Extended_Tools/script/effects/effects.xml
+++ b/totalRP3_Extended_Tools/script/effects/effects.xml
@@ -77,6 +77,25 @@
 	</Frame>
 
 	<!-- *_*_*_*_*_*_*_*_*_*  -->
+	<!--    Run Macro         -->
+	<!-- *_*_*_*_*_*_*_*_*_*  -->
+
+	<Frame name="TRP3_EffectEditorMacro" inherits="TRP3_EditorEffectTemplate" hidden="true">
+		<Size x="500" y="250"/>
+		<Frames>
+			<Frame parentKey="macroText" inherits="TRP3_TextArea">
+				<Size x="260" y="0"/>
+				<Anchors>
+					<Anchor point="TOP" x="0" y="-45"/>
+					<Anchor point="BOTTOM" x="0" y="40"/>
+				</Anchors>
+			</Frame>
+
+		</Frames>
+
+	</Frame>
+
+	<!-- *_*_*_*_*_*_*_*_*_*  -->
 	<!--  Set env variable    -->
 	<!-- *_*_*_*_*_*_*_*_*_*  -->
 

--- a/totalRP3_Extended_Tools/script/script.lua
+++ b/totalRP3_Extended_Tools/script/script.lua
@@ -86,6 +86,7 @@ function TRP3_API.extended.tools.getEffectOperandLocale()
 			"signal_send",
 			"run_workflow",
 			"run_item_workflow",
+			"secure_macro",
 			"script"
 		},
 		order = {

--- a/totalRP3_Extended_Tools/script/script.lua
+++ b/totalRP3_Extended_Tools/script/script.lua
@@ -2,6 +2,7 @@
 -- Total RP 3: Extended features
 --	---------------------------------------------------------------------------
 --	Copyright 2015 Sylvain Cossement (telkostrasz@totalrp3.info)
+--	Copyright 2018 Renaud "Ellypse" Parize <ellypse@totalrp3.info> @EllypseCelwe
 --
 --	Licensed under the Apache License, Version 2.0 (the "License");
 --	you may not use this file except in compliance with the License.


### PR DESCRIPTION
Added secured macro effect

- Any macro command can be run (including /script, /run, /use, /cast)
- This effects is completely ignored during combat.
- This effect can only be run when an item is being used by clicking on it. Conditions are applied and workflow variables can be used. The macro effects are being collected while the workflow is executed and then run in a secure environment.
- Delays are ignored as the macro effect has to be run immediately following a user action.
- This effect has the lowest security level and has to be approved when a creation is received, with a message explaining how much harm can be done with it.