### PR TITLE
Stack splitting bugfixes (#137/#157)

### DIFF
--- a/totalRP3_Extended/inventory/container.lua
+++ b/totalRP3_Extended/inventory/container.lua
@@ -516,7 +516,7 @@ local function splitStack(slot, quantity)
 	end
 end
 
-local IsShiftKeyDown, IsControlKeyDown, OpenStackSplitFrame = IsShiftKeyDown, IsControlKeyDown, OpenStackSplitFrame;
+local IsShiftKeyDown, IsControlKeyDown = IsShiftKeyDown, IsControlKeyDown;
 local COLUMN_SPACING = 43;
 local ROW_SPACING = 42;
 local CONTAINER_SLOT_UPDATE_FREQUENCY = 0.15;
@@ -553,7 +553,7 @@ local function initContainerSlot(slot, simpleLeftClick, lootBuilder)
 			if not self.loot and self.info and not TRP3_API.inventory.isInTransaction(self.info) then
 				if button == "LeftButton" then
 					if IsShiftKeyDown() and (self.info.count or 1) > 1 then
-						OpenStackSplitFrame(self.info.count, self, "BOTTOMRIGHT", "TOPRIGHT");
+						StackSplitFrame:OpenStackSplitFrame(self.info.count, self, "BOTTOMRIGHT", "TOPRIGHT");
 					elseif simpleLeftClick then
 						simpleLeftClick(self);
 					end

--- a/totalRP3_Extended/inventory/inventory.lua
+++ b/totalRP3_Extended/inventory/inventory.lua
@@ -395,6 +395,8 @@ end
 TRP3_API.inventory.removeSlotContent = removeSlotContent;
 
 local function splitSlot(slot, container, quantity)
+	if slot.count == quantity then return end	-- Ignoring the command if we're trying to split the stack into itself.
+
 	local containerClass = getClass(container.id);
 
 	local emptySlotID;


### PR DESCRIPTION
Blizzard changed the OpenStackSplitFrame function to be called from the StackSplitFrame rather than standalone in 8.1, which broke the splitting function in Extended. First commit fixes this issue (#157).

While I was on the topic of splitting stacks, I went ahead and fixed issue #137 about splitting a stack by the maximum amount, which was leaving a "phantom" slot containing 0 occurences of the item. Splitting a stack by the maximum amount now leaves it untouched.