### PR TITLE
Fix invalid or deprecated calls to Communications

### DIFF
--- a/totalRP3_Extended/inventory/inspection.lua
+++ b/totalRP3_Extended/inventory/inspection.lua
@@ -16,7 +16,7 @@
 --	limitations under the License.
 ----------------------------------------------------------------------------------
 local Globals, Events, Utils = TRP3_API.globals, TRP3_API.events, TRP3_API.utils;
-local Comm = AddOn_TotalRP3.Communications;
+local Communications = AddOn_TotalRP3.Communications;
 local tinsert, tostring, _G, wipe, pairs, time, tonumber = tinsert, tostring, _G, wipe, pairs, time, tonumber;
 local getClass, isContainerByClassID, isUsableByClass = TRP3_API.extended.getClass, TRP3_API.inventory.isContainerByClassID, TRP3_API.inventory.isUsableByClass;
 local loc = TRP3_API.loc;
@@ -32,8 +32,8 @@ local decorateSlot;
 
 local INSPECTION_REQUEST = "IIRQ";
 local INSPECTION_RESPONSE = "IIRS";
-local REQUEST_PRIORITY = Comm.PRIORITIES.MEDIUM;
-local RESPONSE_PRIORITY = Comm.PRIORITIES.LOW;
+local REQUEST_PRIORITY = Communications.PRIORITIES.MEDIUM;
+local RESPONSE_PRIORITY = Communications.PRIORITIES.LOW;
 
 local loadingTemplate;
 
@@ -94,21 +94,21 @@ local function receiveRequest(request, sender)
 		end
 	end
 
-	Comm.sendObject(INSPECTION_RESPONSE, response, sender, RESPONSE_PRIORITY, reservedMessageID);
+	Communications.sendObject(INSPECTION_RESPONSE, response, sender, RESPONSE_PRIORITY, reservedMessageID);
 end
 
 local function sendRequest()
-	local reservedMessageID = Comm.getMessageIDAndIncrement();
+	local reservedMessageID = Communications.getMessageIDAndIncrement();
 	local data = {reservedMessageID};
 	inspectionFrame.time = time();
 	inspectionFrame.Main.Model.Loading:SetText("... " .. loc.INV_PAGE_WAIT .. " ...");
-	Comm.addMessageIDHandler(inspectionFrame.current, reservedMessageID, function(_, total, current)
+	Communications.addMessageIDHandler(inspectionFrame.current, reservedMessageID, function(_, total, current)
 		inspectionFrame.Main.Model.Loading:SetText(loadingTemplate:format(current / total * 100));
 		if current == total then
 			inspectionFrame.Main.Model.Loading:Hide();
 		end
 	end);
-	Comm.sendObject(INSPECTION_REQUEST, data, inspectionFrame.current, REQUEST_PRIORITY);
+	Communications.sendObject(INSPECTION_REQUEST, data, inspectionFrame.current, REQUEST_PRIORITY);
 end
 
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -216,8 +216,8 @@ function inspectionFrame.init()
 	end);
 
 	-- Register prefix for data exchange
-	Comm.registerProtocolPrefix(INSPECTION_REQUEST, receiveRequest);
-	Comm.registerProtocolPrefix(INSPECTION_RESPONSE, receiveResponse);
+	Communications.registerSubSystemPrefix(INSPECTION_REQUEST, receiveRequest);
+	Communications.registerSubSystemPrefix(INSPECTION_RESPONSE, receiveResponse);
 
 	TRP3_API.ui.frame.setupMove(inspectionFrame);
 end

--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -17,14 +17,14 @@
 ----------------------------------------------------------------------------------
 local Globals, Events, Utils = TRP3_API.globals, TRP3_API.events, TRP3_API.utils;
 local EMPTY = Globals.empty;
-local Comm = AddOn_TotalRP3.Communications;
+local Communications = AddOn_TotalRP3.Communications;
 local type, tremove = type, tremove;
 local tinsert, assert, strtrim, tostring, wipe, pairs, sqrt, tonumber = tinsert, assert, strtrim, tostring, wipe, pairs, sqrt, tonumber;
 local getClass, isContainerByClassID, isUsableByClass = TRP3_API.extended.getClass, TRP3_API.inventory.isContainerByClassID, TRP3_API.inventory.isUsableByClass;
 local loc = TRP3_API.loc;
 local getItemLink = TRP3_API.inventory.getItemLink;
 local setTooltipForSameFrame = TRP3_API.ui.tooltip.setTooltipForSameFrame;
-local broadcast = TRP3_API.communication.broadcast;
+local broadcast = Communications.broadcast;
 
 local dropFrame, stashEditFrame, stashFoundFrame = TRP3_DropSearchFrame, TRP3_StashEditFrame, TRP3_StashFoundFrame;
 local callForStashRefresh;
@@ -480,12 +480,12 @@ local classExists = TRP3_API.extended.classExists;
 function callForStashRefresh(target, stashID)
 	stashContainer.DurabilityText:SetText(loc.DR_STASHES_SYNC);
 	stashContainer.sync = true;
-	local reservedMessageID = Comm.getMessageIDAndIncrement();
+	local reservedMessageID = Communications.getMessageIDAndIncrement();
 	stashContainer.WeightText:SetText("0 %");
-	Comm.addMessageIDHandler(target, reservedMessageID, function(_, total, current)
+	Communications.addMessageIDHandler(target, reservedMessageID, function(_, total, current)
 		stashContainer.WeightText:SetFormattedText("%0.2f %%", current / total * 100);
 	end);
-	Comm.sendObject(STASH_TOTAL_REQUEST, {reservedMessageID, stashID}, target, Comm.PRIORITIES.HIGH);
+	Communications.sendObject(STASH_TOTAL_REQUEST, { reservedMessageID, stashID}, target, Communications.PRIORITIES.HIGH);
 end
 
 local function onUnstashResponse(response, sender)
@@ -553,7 +553,7 @@ local function onUnstashRequest(request, sender)
 						response.id = rootID;
 						response.class = localRootClass;
 					end
-					Comm.sendObject(STASH_ITEM_RESPONSE, response, sender, Comm.PRIORITIES.LOW, reservedMessageID);
+					Communications.sendObject(STASH_ITEM_RESPONSE, response, sender, Communications.PRIORITIES.LOW, reservedMessageID);
 
 					-- Remove from our stash
 					tremove(stash.item, slotID);
@@ -568,7 +568,7 @@ local function onUnstashRequest(request, sender)
 		end
 	end
 
-	Comm.sendObject(STASH_ITEM_RESPONSE, "0", sender, Comm.PRIORITIES.LOW, reservedMessageID);
+	Communications.sendObject(STASH_ITEM_RESPONSE, "0", sender, Communications.PRIORITIES.LOW, reservedMessageID);
 end
 
 function TRP3_API.inventory.unstashSlot(slotFrom, container2, slot2)
@@ -588,18 +588,18 @@ function TRP3_API.inventory.unstashSlot(slotFrom, container2, slot2)
 	stashContainer.toSlot = slot2;
 	stashContainer.DurabilityText:SetText(loc.IT_EX_DOWNLOAD);
 	stashContainer.sync = true;
-	local reservedMessageID = Comm.getMessageIDAndIncrement();
+	local reservedMessageID = Communications.getMessageIDAndIncrement();
 	stashContainer.WeightText:SetText("0 %");
-	Comm.addMessageIDHandler(stashContainer.sharedData[1], reservedMessageID, function(_, total, current)
+	Communications.addMessageIDHandler(stashContainer.sharedData[1], reservedMessageID, function(_, total, current)
 		stashContainer.WeightText:SetFormattedText("%0.2f %%", current / total * 100);
 	end);
-	Comm.sendObject(STASH_ITEM_REQUEST, {
+	Communications.sendObject(STASH_ITEM_REQUEST, {
 		rID = reservedMessageID,
 		stashID = stashID,
 		slotID = slotID,
 		rootID = rootClassID,
 		v = version
-	}, stashContainer.sharedData[1], Comm.PRIORITIES.HIGH);
+	}, stashContainer.sharedData[1], Communications.PRIORITIES.HIGH);
 end
 
 local function receiveStashResponse(response, sender)
@@ -635,11 +635,11 @@ local function receiveStashRequest(data, sender)
 				Utils.table.copy(slot.class.CO, class.CO or EMPTY);
 				Utils.table.copy(slot.class.US, class.US or EMPTY);
 			end
-			Comm.sendObject(STASH_TOTAL_RESPONSE, response, sender, Comm.PRIORITIES.LOW, reservedMessageID);
+			Communications.sendObject(STASH_TOTAL_RESPONSE, response, sender, Communications.PRIORITIES.LOW, reservedMessageID);
 			return;
 		end
 	end
-	Comm.sendObject(STASH_TOTAL_RESPONSE, "0", sender, Comm.PRIORITIES.LOW, reservedMessageID);
+	Communications.sendObject(STASH_TOTAL_RESPONSE, "0", sender, Communications.PRIORITIES.LOW, reservedMessageID);
 end
 
 local function decorateStashSlot(slot, index)
@@ -716,7 +716,7 @@ local function receivedStashesRequest(sender, mapID, posY, posX, castID)
 				for index, slot in pairs(stash.item) do
 					total = total + 1;
 				end
-				Comm.broadcast.sendP2PMessage(sender, SEARCH_STASHES_COMMAND, stash.id, stash.BA.NA, stash.BA.IC, total, castID, stash.CR);
+				Communications.broadcast.sendP2PMessage(sender, SEARCH_STASHES_COMMAND, stash.id, stash.BA.NA, stash.BA.IC, total, castID, stash.CR);
 			end
 		end
 	end
@@ -921,8 +921,8 @@ function dropFrame.init()
 	setTooltipForSameFrame(stashEditFrame.hidden, "RIGHT", 0, 5, loc.DR_STASHES_HIDE, loc.DR_STASHES_HIDE_TT);
 
 	initStashContainer();
-	Comm.broadcast.registerCommand(SEARCH_STASHES_COMMAND, receivedStashesRequest);
-	Comm.broadcast.registerP2PCommand(SEARCH_STASHES_COMMAND, receivedStashesResponse);
+	Communications.broadcast.registerCommand(SEARCH_STASHES_COMMAND, receivedStashesRequest);
+	Communications.broadcast.registerP2PCommand(SEARCH_STASHES_COMMAND, receivedStashesResponse);
 
 	TRP3_API.ui.frame.setupMove(stashFoundFrame);
 	createRefreshOnFrame(stashFoundFrame, 0.15, function(self)
@@ -934,10 +934,10 @@ function dropFrame.init()
 	end);
 
 	-- Stash list
-	Comm.registerProtocolPrefix(STASH_TOTAL_REQUEST, receiveStashRequest);
-	Comm.registerProtocolPrefix(STASH_TOTAL_RESPONSE, receiveStashResponse);
-	Comm.registerProtocolPrefix(STASH_ITEM_REQUEST, onUnstashRequest);
-	Comm.registerProtocolPrefix(STASH_ITEM_RESPONSE, onUnstashResponse);
+	Communications.registerSubSystemPrefix(STASH_TOTAL_REQUEST, receiveStashRequest);
+	Communications.registerSubSystemPrefix(STASH_TOTAL_RESPONSE, receiveStashResponse);
+	Communications.registerSubSystemPrefix(STASH_ITEM_REQUEST, onUnstashRequest);
+	Communications.registerSubSystemPrefix(STASH_ITEM_RESPONSE, onUnstashResponse);
 
 	stashFoundFrame.widgetTab = {};
 	for i=1, 6 do

--- a/totalRP3_Extended/inventory/inventory_exchange.lua
+++ b/totalRP3_Extended/inventory/inventory_exchange.lua
@@ -16,7 +16,7 @@
 --	limitations under the License.
 ----------------------------------------------------------------------------------
 local Globals, Events, Utils = TRP3_API.globals, TRP3_API.events, TRP3_API.utils;
-local Comm = AddOn_TotalRP3.Communications;
+local Communications = AddOn_TotalRP3.Communications;
 local tonumber, assert, strsplit, tostring, wipe, pairs, type = tonumber, assert, strsplit, tostring, wipe, pairs, type;
 local getClass, isContainerByClassID, isUsableByClass = TRP3_API.extended.getClass, TRP3_API.inventory.isContainerByClassID, TRP3_API.inventory.isUsableByClass;
 local isContainerByClass, getItemTextLine = TRP3_API.inventory.isContainerByClass, TRP3_API.inventory.getItemTextLine;
@@ -39,8 +39,8 @@ local DATA_EXCHANGE_QUERY_PREFIX = "IEDE";
 local SEND_DATA_QUERY_PREFIX = "IESD";
 local FINISH_EXCHANGE_QUERY_PREFIX = "IEFE";
 
-local SEND_DATE_PRIORITY = Comm.PRIORITIES.LOW;
-local START_EXCHANGE_PRIORITY = Comm.PRIORITIES.MEDIUM;
+local SEND_DATE_PRIORITY = Communications.PRIORITIES.LOW;
+local START_EXCHANGE_PRIORITY = Communications.PRIORITIES.MEDIUM;
 
 local MAX_MESSAGES_SIZE = 25;
 
@@ -319,7 +319,7 @@ local function addToExchange(container, slotID)
 				qa = itemClass.BA.QA,
 				id = rootClassID,
 				vn = rootClass.MD.V,
-				si = Comm.estimateStructureLoad(rootClass);
+				si = Communications.estimateStructureLoad(rootClass);
 			};
 			slotMapping[slotInfo] = {container, slotID};
 			found = true;
@@ -336,7 +336,7 @@ local function addToExchange(container, slotID)
 
 	drawUI();
 
-	Comm.sendObject(UPDATE_EXCHANGE_QUERY_PREFIX, exchangeFrame.myData, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
+	Communications.sendObject(UPDATE_EXCHANGE_QUERY_PREFIX, exchangeFrame.myData, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
 end
 TRP3_API.inventory.addToExchange = addToExchange;
 
@@ -349,7 +349,7 @@ local function startEmptyExchangeWithUnit(targetID)
 	exchangeFrame.myData.ok = nil;
 	exchangeFrame.yourData.ok = nil;
 	drawUI();
-	Comm.sendObject(UPDATE_EXCHANGE_QUERY_PREFIX, exchangeFrame.myData, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
+	Communications.sendObject(UPDATE_EXCHANGE_QUERY_PREFIX, exchangeFrame.myData, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
 end
 TRP3_API.inventory.startEmptyExchangeWithUnit = startEmptyExchangeWithUnit;
 
@@ -426,7 +426,7 @@ end
 
 function sendCurrentState()
 	assert(exchangeFrame.targetID, "No targetID");
-	Comm.sendObject(UPDATE_EXCHANGE_QUERY_PREFIX, exchangeFrame.myData, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
+	Communications.sendObject(UPDATE_EXCHANGE_QUERY_PREFIX, exchangeFrame.myData, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
 end
 
 function sendItemDataRequest(rootClassId, rootClassVersion)
@@ -435,7 +435,7 @@ function sendItemDataRequest(rootClassId, rootClassVersion)
 		return;
 	end
 
-	local reservedMessageID = Comm.getMessageIDAndIncrement();
+	local reservedMessageID = Communications.getMessageIDAndIncrement();
 	local request = {
 		id = rootClassId,
 		v = rootClassVersion,
@@ -443,14 +443,14 @@ function sendItemDataRequest(rootClassId, rootClassVersion)
 	};
 
 	currentDownloads[rootClassId] = 0;
-	Comm.addMessageIDHandler(exchangeFrame.targetID, reservedMessageID, function(_, total, current)
+	Communications.addMessageIDHandler(exchangeFrame.targetID, reservedMessageID, function(_, total, current)
 		currentDownloads[rootClassId] = current / total;
 		reloadDownloads();
 		if current == total then
 			currentDownloads[rootClassId] = nil;
 		end
 	end);
-	Comm.sendObject(DATA_EXCHANGE_QUERY_PREFIX, request, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
+	Communications.sendObject(DATA_EXCHANGE_QUERY_PREFIX, request, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
 	reloadDownloads();
 end
 
@@ -465,7 +465,7 @@ local function receivedDataRequest(request, sender)
 		class = class;
 	}
 
-	Comm.sendObject(SEND_DATA_QUERY_PREFIX, response, sender, SEND_DATE_PRIORITY, messageID);
+	Communications.sendObject(SEND_DATA_QUERY_PREFIX, response, sender, SEND_DATE_PRIORITY, messageID);
 end
 
 local function receivedDataResponse(response, sender)
@@ -504,7 +504,7 @@ local function receivedAccept(_, sender)
 		exchangeFrame.yourData.ok = true;
 		drawUI();
 		if exchangeFrame.myData.ok then
-			Comm.sendObject(FINISH_EXCHANGE_QUERY_PREFIX, "", exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
+			Communications.sendObject(FINISH_EXCHANGE_QUERY_PREFIX, "", exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
 			receivedFinish(nil, sender);
 		end
 	else
@@ -514,7 +514,7 @@ end
 
 -- Send accept to the other side
 function sendAcceptExchange()
-	Comm.sendObject(ACCEPT_EXCHANGE_QUERY_PREFIX, exchangeFrame.myData, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
+	Communications.sendObject(ACCEPT_EXCHANGE_QUERY_PREFIX, exchangeFrame.myData, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
 end
 
 local function receivedUpdate(data, sender)
@@ -552,7 +552,7 @@ end
 
 function sendCancel(sender)
 	if sender or exchangeFrame.targetID then
-		Comm.sendObject(CANCEL_EXCHANGE_QUERY_PREFIX, "", sender or exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
+		Communications.sendObject(CANCEL_EXCHANGE_QUERY_PREFIX, "", sender or exchangeFrame.targetID, START_EXCHANGE_PRIORITY);
 	end
 end
 
@@ -605,12 +605,12 @@ function exchangeFrame.init()
 	exchangeFrame.Background:SetTexture("Interface\\BankFrame\\Bank-Background", true, true);
 
 	-- Register prefix for data exchange
-	Comm.registerProtocolPrefix(UPDATE_EXCHANGE_QUERY_PREFIX, receivedUpdate);
-	Comm.registerProtocolPrefix(CANCEL_EXCHANGE_QUERY_PREFIX, receivedCancel);
-	Comm.registerProtocolPrefix(ACCEPT_EXCHANGE_QUERY_PREFIX, receivedAccept);
-	Comm.registerProtocolPrefix(DATA_EXCHANGE_QUERY_PREFIX, receivedDataRequest);
-	Comm.registerProtocolPrefix(SEND_DATA_QUERY_PREFIX, receivedDataResponse);
-	Comm.registerProtocolPrefix(FINISH_EXCHANGE_QUERY_PREFIX, receivedFinish);
+	Communications.registerSubSystemPrefix(UPDATE_EXCHANGE_QUERY_PREFIX, receivedUpdate);
+	Communications.registerSubSystemPrefix(CANCEL_EXCHANGE_QUERY_PREFIX, receivedCancel);
+	Communications.registerSubSystemPrefix(ACCEPT_EXCHANGE_QUERY_PREFIX, receivedAccept);
+	Communications.registerSubSystemPrefix(DATA_EXCHANGE_QUERY_PREFIX, receivedDataRequest);
+	Communications.registerSubSystemPrefix(SEND_DATA_QUERY_PREFIX, receivedDataResponse);
+	Communications.registerSubSystemPrefix(FINISH_EXCHANGE_QUERY_PREFIX, receivedFinish);
 
 	TRP3_API.events.listenToEvent(TRP3_API.security.EVENT_SECURITY_CHANGED, function(arg)
 		if exchangeFrame:IsVisible() then

--- a/totalRP3_Extended/main.lua
+++ b/totalRP3_Extended/main.lua
@@ -425,7 +425,7 @@ local function onStart()
 	-- Signal
 	TRP3_API.extended.SIGNAL_PREFIX = "EXSI";
 	TRP3_API.extended.SIGNAL_EVENT = "TRP3_SIGNAL",
-	TRP3_API.communication.registerProtocolPrefix(TRP3_API.extended.SIGNAL_PREFIX, function(arg, sender)
+	AddOn_TotalRP3.Communications.registerSubSystemPrefix(TRP3_API.extended.SIGNAL_PREFIX, function(arg, sender)
 		if sender ~= Globals.player_id then
 			Log.log(("Received signal from %s"):format(sender));
 			Events.fireEvent(TRP3_API.extended.SIGNAL_EVENT, arg.i, arg.v, sender);

--- a/totalRP3_Extended/misc/sounds.lua
+++ b/totalRP3_Extended/misc/sounds.lua
@@ -16,7 +16,8 @@
 --	limitations under the License.
 ----------------------------------------------------------------------------------
 
-local Globals, Comm, Utils = TRP3_API.globals, TRP3_API.communication, TRP3_API.utils;
+local Communications = AddOn_TotalRP3.Communications;
+local Globals, Utils = TRP3_API.globals, TRP3_API.utils;
 local pairs, strsplit, floor, sqrt, tonumber = pairs, strsplit, math.floor, sqrt, tonumber;
 local getConfigValue = TRP3_API.configuration.getValue;
 local loc = TRP3_API.loc;
@@ -42,7 +43,7 @@ function Utils.music.playLocalSoundID(soundID, channel, distance, source)
 	-- Get current position
 	local posY, posX, posZ, instanceID = getPosition();
 	if instanceID then
-		Comm.broadcast.broadcast(LOCAL_SOUND_COMMAND, soundID, channel, distance, instanceID, posY, posX, posZ);
+		Communications.broadcast.broadcast(LOCAL_SOUND_COMMAND, soundID, channel, distance, instanceID, posY, posX, posZ);
 	end
 end
 
@@ -50,13 +51,13 @@ function Utils.music.playLocalMusic(soundID, distance, source)
 	-- Get current position
 	local posY, posX, posZ, instanceID = getPosition();
 	if instanceID then
-		Comm.broadcast.broadcast(LOCAL_SOUND_COMMAND, soundID, "Music" , distance, instanceID, posY, posX, posZ);
+		Communications.broadcast.broadcast(LOCAL_SOUND_COMMAND, soundID, "Music" , distance, instanceID, posY, posX, posZ);
 	end
 end
 
 function Utils.music.stopLocalSoundID(soundID, channel)
 	soundID = soundID or 0;
-	Comm.broadcast.broadcast(LOCAL_STOPSOUND_COMMAND, soundID, channel);
+	Communications.broadcast.broadcast(LOCAL_STOPSOUND_COMMAND, soundID, channel);
 end
 
 function Utils.music.stopLocalMusic(soundID)
@@ -70,7 +71,7 @@ local function isInRadius(maxDistance, posY, posX, myPosY, myPosX)
 end
 
 local function initSharedSound()
-	Comm.broadcast.registerCommand(LOCAL_SOUND_COMMAND, function(sender, soundID, channel, distance, instanceID, posY, posX, posZ)
+	Communications.broadcast.registerCommand(LOCAL_SOUND_COMMAND, function(sender, soundID, channel, distance, instanceID, posY, posX, posZ)
 		if getConfigValue(TRP3_API.extended.CONFIG_SOUNDS_ACTIVE) then
 			if soundID and channel and distance and instanceID and posY and posX and posZ then
 				distance = tonumber(distance) or 0;
@@ -111,7 +112,7 @@ local function initSharedSound()
 		end
 	end);
 
-	Comm.broadcast.registerCommand(LOCAL_STOPSOUND_COMMAND, function(sender, soundID, channel)
+	Communications.broadcast.registerCommand(LOCAL_STOPSOUND_COMMAND, function(sender, soundID, channel)
 		if getConfigValue(TRP3_API.extended.CONFIG_SOUNDS_ACTIVE) then
 			Utils.music.stopSoundID(soundID, channel, sender);
 		end


### PR DESCRIPTION
Some remaining calls to the old `TRP3_API.communication` API were either no longer working (my bad for not testing properly) or still using deprecated methods. This cleans everything to be in a correct state.