### PR TITLE
Fixed Communications and Map deprecated calls

### DIFF
--- a/totalRP3_Extended/inventory/inspection.lua
+++ b/totalRP3_Extended/inventory/inspection.lua
@@ -26,8 +26,6 @@ local CreateFrame = CreateFrame;
 local inspectionFrame = TRP3_InspectionFrame;
 local decorateSlot;
 
-local messageIDDispatcher = TRP3_API.Ellyb.EventsDispatcher();
-
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- DATA EXCHANGE
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -104,12 +102,10 @@ local function sendRequest()
 	local data = {reservedMessageID};
 	inspectionFrame.time = time();
 	inspectionFrame.Main.Model.Loading:SetText("... " .. loc.INV_PAGE_WAIT .. " ...");
-	messageIDDispatcher:RegisterCallback(reservedMessageID, function(senderID, total, current)
-		if senderID == inspectionFrame.current then
-			inspectionFrame.Main.Model.Loading:SetText(loadingTemplate:format(current / total * 100));
-			if current == total then
-				inspectionFrame.Main.Model.Loading:Hide();
-			end
+	Communications.registerMessageTokenProgressHandler(reservedMessageID, inspectionFrame.current, function(senderID, total, current)
+		inspectionFrame.Main.Model.Loading:SetText(loadingTemplate:format(current / total * 100));
+		if current == total then
+			inspectionFrame.Main.Model.Loading:Hide();
 		end
 	end);
 	Communications.sendObject(INSPECTION_REQUEST, data, inspectionFrame.current, REQUEST_PRIORITY);

--- a/totalRP3_Extended/inventory/inspection.lua
+++ b/totalRP3_Extended/inventory/inspection.lua
@@ -105,7 +105,7 @@ local function sendRequest()
 	inspectionFrame.time = time();
 	inspectionFrame.Main.Model.Loading:SetText("... " .. loc.INV_PAGE_WAIT .. " ...");
 	messageIDDispatcher:RegisterCallback(reservedMessageID, function(senderID, total, current)
-		if senderID == sender then
+		if senderID == inspectionFrame.current then
 			inspectionFrame.Main.Model.Loading:SetText(loadingTemplate:format(current / total * 100));
 			if current == total then
 				inspectionFrame.Main.Model.Loading:Hide();

--- a/totalRP3_Extended/inventory/inspection.lua
+++ b/totalRP3_Extended/inventory/inspection.lua
@@ -102,7 +102,7 @@ local function sendRequest()
 	local data = {reservedMessageID};
 	inspectionFrame.time = time();
 	inspectionFrame.Main.Model.Loading:SetText("... " .. loc.INV_PAGE_WAIT .. " ...");
-	Communications.registerMessageTokenProgressHandler(reservedMessageID, inspectionFrame.current, function(senderID, total, current)
+	Communications.registerMessageTokenProgressHandler(reservedMessageID, inspectionFrame.current, function(_, total, current)
 		inspectionFrame.Main.Model.Loading:SetText(loadingTemplate:format(current / total * 100));
 		if current == total then
 			inspectionFrame.Main.Model.Loading:Hide();

--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -41,7 +41,8 @@ local function dropCommon(lootInfo)
 	local posY, posX, posZ = UnitPosition("player");
 
 	-- We still need map position for potential marker placement
-	local mapID, mapX, mapY = TRP3_API.map.getCurrentCoordinates("player");
+	local mapID = AddOn_TotalRP3.Map.getPlayerMapID();
+	local mapX, mapY = AddOn_TotalRP3.Map.getPlayerCoordinates();
 
 	-- Pack the data
 	local groundData = {
@@ -59,7 +60,7 @@ local function dropCommon(lootInfo)
 end
 
 function TRP3_API.inventory.dropItemDirect(slotInfo)
-	if TRP3_API.map.getCurrentCoordinates("player") then
+	if AddOn_TotalRP3.Map.getPlayerCoordinates() then
 		dropCommon(slotInfo);
 		local count = slotInfo.count or 1;
 		local link = getItemLink(getClass(slotInfo.id));
@@ -219,7 +220,8 @@ local function saveStash()
 
 	-- Proper coordinates
 	local posY, posX, posZ = UnitPosition("player");
-	local mapID, mapX, mapY = TRP3_API.map.getCurrentCoordinates("player");
+	local mapID = AddOn_TotalRP3.Map.getPlayerMapID();
+	local mapX, mapY = AddOn_TotalRP3.Map.getPlayerCoordinates();
 
 	if posX and posY then
 		stash.posX = posX;
@@ -743,7 +745,7 @@ local function onDropButtonAction(actionID)
 	if actionID == ACTION_SEARCH_MY then
 		searchForItems();
 	elseif actionID == ACTION_STASH_CREATE then
-		if TRP3_API.map.getCurrentCoordinates("player") then
+		if AddOn_TotalRP3.Map.getPlayerCoordinates() then
 			openStashEditor(nil);
 		else
 			Utils.message.displayMessage(loc.DR_STASHES_ERROR_INSTANCE, Utils.message.type.ALERT_MESSAGE);
@@ -881,7 +883,7 @@ function dropFrame.init()
 		button2 = CANCEL,
 		button3 = loc.DR_POPUP,
 		OnShow = function(self)
-			if TRP3_API.map.getCurrentCoordinates("player") then
+			if AddOn_TotalRP3.Map.getPlayerCoordinates() then
 				self.button3:Enable();
 			else
 				self.button3:Disable();

--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -482,7 +482,7 @@ function callForStashRefresh(target, stashID)
 	stashContainer.sync = true;
 	local reservedMessageID = Communications.getNewMessageToken();
 	stashContainer.WeightText:SetText("0 %");
-	Communications.registerMessageTokenProgressHandler(reservedMessageID, target, function(senderID, total, current)
+	Communications.registerMessageTokenProgressHandler(reservedMessageID, target, function(_, total, current)
 		stashContainer.WeightText:SetFormattedText("%0.2f %%", current / total * 100);
 	end);
 	Communications.sendObject(STASH_TOTAL_REQUEST, { reservedMessageID, stashID}, target, Communications.PRIORITIES.HIGH);
@@ -590,7 +590,7 @@ function TRP3_API.inventory.unstashSlot(slotFrom, container2, slot2)
 	stashContainer.sync = true;
 	local reservedMessageID = Communications.getNewMessageToken();
 	stashContainer.WeightText:SetText("0 %");
-	Communications.registerMessageTokenProgressHandler(reservedMessageID, stashContainer.sharedData[1], function(senderID, total, current)
+	Communications.registerMessageTokenProgressHandler(reservedMessageID, stashContainer.sharedData[1], function(_, total, current)
 		stashContainer.WeightText:SetFormattedText("%0.2f %%", current / total * 100);
 	end);
 	Communications.sendObject(STASH_ITEM_REQUEST, {

--- a/totalRP3_Extended/inventory/inventory_drop.lua
+++ b/totalRP3_Extended/inventory/inventory_drop.lua
@@ -32,8 +32,6 @@ local dropData, stashesData;
 
 local UnitPosition = TRP3_API.extended.getUnitPositionSafe;
 
-local messageIDDispatcher = TRP3_API.Ellyb.EventsDispatcher();
-
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- Drop
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -484,10 +482,8 @@ function callForStashRefresh(target, stashID)
 	stashContainer.sync = true;
 	local reservedMessageID = Communications.getNewMessageToken();
 	stashContainer.WeightText:SetText("0 %");
-	messageIDDispatcher:RegisterCallback(reservedMessageID, function(senderID, total, current)
-		if senderID == target then
-			stashContainer.WeightText:SetFormattedText("%0.2f %%", current / total * 100);
-		end
+	Communications.registerMessageTokenProgressHandler(reservedMessageID, target, function(senderID, total, current)
+		stashContainer.WeightText:SetFormattedText("%0.2f %%", current / total * 100);
 	end);
 	Communications.sendObject(STASH_TOTAL_REQUEST, { reservedMessageID, stashID}, target, Communications.PRIORITIES.HIGH);
 end
@@ -594,10 +590,8 @@ function TRP3_API.inventory.unstashSlot(slotFrom, container2, slot2)
 	stashContainer.sync = true;
 	local reservedMessageID = Communications.getNewMessageToken();
 	stashContainer.WeightText:SetText("0 %");
-	messageIDDispatcher:RegisterCallback(reservedMessageID, function(senderID, total, current)
-		if senderID == stashContainer.sharedData[1] then
-			stashContainer.WeightText:SetFormattedText("%0.2f %%", current / total * 100);
-		end
+	Communications.registerMessageTokenProgressHandler(reservedMessageID, stashContainer.sharedData[1], function(senderID, total, current)
+		stashContainer.WeightText:SetFormattedText("%0.2f %%", current / total * 100);
 	end);
 	Communications.sendObject(STASH_ITEM_REQUEST, {
 		rID = reservedMessageID,

--- a/totalRP3_Extended/inventory/inventory_exchange.lua
+++ b/totalRP3_Extended/inventory/inventory_exchange.lua
@@ -46,8 +46,6 @@ local MAX_MESSAGES_SIZE = 25;
 
 local currentDownloads = {};
 
-local messageIDDispatcher = TRP3_API.Ellyb.EventsDispatcher();
-
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
 -- UI
 --*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
@@ -445,13 +443,11 @@ function sendItemDataRequest(rootClassId, rootClassVersion)
 	};
 
 	currentDownloads[rootClassId] = 0;
-	messageIDDispatcher:RegisterCallback(reservedMessageID, function(senderID, total, current)
-		if senderID == exchangeFrame.targetID then
-			currentDownloads[rootClassId] = current / total;
-			reloadDownloads();
-			if current == total then
-				currentDownloads[rootClassId] = nil;
-			end
+	Communications.registerMessageTokenProgressHandler(reservedMessageID, exchangeFrame.targetID, function(senderID, total, current)
+		currentDownloads[rootClassId] = current / total;
+		reloadDownloads();
+		if current == total then
+			currentDownloads[rootClassId] = nil;
 		end
 	end);
 	Communications.sendObject(DATA_EXCHANGE_QUERY_PREFIX, request, exchangeFrame.targetID, START_EXCHANGE_PRIORITY);

--- a/totalRP3_Extended/inventory/inventory_exchange.lua
+++ b/totalRP3_Extended/inventory/inventory_exchange.lua
@@ -443,7 +443,7 @@ function sendItemDataRequest(rootClassId, rootClassVersion)
 	};
 
 	currentDownloads[rootClassId] = 0;
-	Communications.registerMessageTokenProgressHandler(reservedMessageID, exchangeFrame.targetID, function(senderID, total, current)
+	Communications.registerMessageTokenProgressHandler(reservedMessageID, exchangeFrame.targetID, function(_, total, current)
 		currentDownloads[rootClassId] = current / total;
 		reloadDownloads();
 		if current == total then


### PR DESCRIPTION
While testing the current 1.3.1 beta, I stumbled upon a few issues that needed fixing : 
- Deprecated Communications calls that weren't covered by the wrapper anymore (`getMessageIDAndIncrement` became `getNewMessageToken`, `addMessageIDHandler` became `registerMessageTokenProgressHandler`). The wrapper for `addMessageIDHandler` was actually wrong, so correcting those calls allowed to fix issues like the "Waiting for response" text at the bottom of the inspection window lingering.
- Deprecated calls to `TRP3_API.map.getCurrentCoordinates` (became `AddOn_TotalRP3.Map.getPlayerMapID` and `AddOn_TotalRP3.Map.getPlayerCoordinates`) which, while still valid in the current TRP3 release version, are obsolete with the dev branch cleaning. Better to fix those now while we're at it.